### PR TITLE
Add docker tag version type

### DIFF
--- a/source/Octopus.Versioning.Tests/VersionTests.cs
+++ b/source/Octopus.Versioning.Tests/VersionTests.cs
@@ -6,7 +6,7 @@ namespace Octopus.Versioning.Tests.Versions
     public class VersionTests
     {
         [Test]
-        public void TestMavenComparasion()
+        public void TestMavenComparison()
         {
             var versionOne = VersionFactory.CreateMavenVersion("1.0.0");
 
@@ -20,7 +20,7 @@ namespace Octopus.Versioning.Tests.Versions
         }
 
         [Test]
-        public void TestBunchMoreComparasions()
+        public void TestBunchMoreComparisons()
         {
             Assert.Less(VersionFactory.CreateMavenVersion("1.0-beta1-SNAPSHOT"),
                 VersionFactory.CreateMavenVersion("1.0-beta1"));
@@ -57,7 +57,7 @@ namespace Octopus.Versioning.Tests.Versions
         }
 
         [Test]
-        public void TestEquilivants()
+        public void TestEquivalents()
         {
             Assert.AreEqual(
                 VersionFactory.CreateMavenVersion("1.0.0.a1"),
@@ -74,6 +74,12 @@ namespace Octopus.Versioning.Tests.Versions
         public void TestInvalidVersion()
         {
             Assert.False(VersionFactory.TryCreateVersion("1.0.*", out var version, VersionFormat.Semver));
+        }
+
+        [Test]
+        public void TestDockerTagComparison()
+        {
+            Assert.AreEqual(VersionFactory.CreateDockerTag("latest"), VersionFactory.CreateDockerTag("latest"));
         }
     }
 }

--- a/source/Octopus.Versioning/Docker/DockerTag.cs
+++ b/source/Octopus.Versioning/Docker/DockerTag.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace Octopus.Versioning.Docker
+{
+    public class DockerTag : IVersion
+    {
+        public DockerTag(string tag)
+        {
+            Tag = tag;
+        }
+        public string Tag { get; }
+        public int Major => throw new NotSupportedException("Docker tags do not support major version parts");
+        public int Minor => throw new NotSupportedException("Docker tags do not support minor version parts");
+        public int Patch => throw new NotSupportedException("Docker tags do not support patch version parts");
+        public int Revision => throw new NotSupportedException("Docker tags do not support revision version parts");
+        public bool IsPrerelease => throw new NotSupportedException("Docker tags do not support pre-release versions");
+        public IEnumerable<string> ReleaseLabels => throw new NotSupportedException("Docker tags do not support release labels");
+        public string Metadata => throw new NotSupportedException("Docker tags do not support metadata version parts");
+        public string Release => throw new NotSupportedException("Docker tags do not support release version parts");
+        public bool HasMetadata => false;
+        public string OriginalString => Tag;
+        public VersionFormat Format => VersionFormat.Docker;
+
+        public override string ToString()
+        {
+            return Tag ?? "latest";
+        }
+
+        private bool Equals(DockerTag other)
+        {
+            return Tag == other.Tag;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((DockerTag) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Tag != null ? Tag.GetHashCode() : 0);
+        }
+
+        public int CompareTo(object obj)
+        {
+            return string.Compare((obj as DockerTag)?.Tag ?? "", Tag, StringComparison.Ordinal);
+        }
+    }
+}

--- a/source/Octopus.Versioning/VersionFactory.cs
+++ b/source/Octopus.Versioning/VersionFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Octopus.CoreUtilities;
+using Octopus.Versioning.Docker;
 using Octopus.Versioning.Maven;
 using Octopus.Versioning.Semver;
 using SemanticVersion = Octopus.Versioning.Semver.SemanticVersion;
@@ -15,6 +16,8 @@ namespace Octopus.Versioning
             {
                 case VersionFormat.Maven:
                     return CreateMavenVersion(input);
+                case VersionFormat.Docker:
+                    return CreateDockerTag(input);
                 default:
                     return CreateSemanticVersion(input);
             }
@@ -26,6 +29,8 @@ namespace Octopus.Versioning
             {
                 case VersionFormat.Maven:
                     return TryCreateMavenVersion(input, out version);
+                case VersionFormat.Docker:
+                    return TryCreateDockerTag(input, out version);
                 default:
                     return TryCreateSemanticVersion(input, out version);
             }
@@ -68,8 +73,6 @@ namespace Octopus.Versioning
             return new SemanticVersion(major, minor, patch, revision, releaseLabels, metadata);
         }
 
-        
-
         public static bool TryCreateMavenVersion(string input, out IVersion version)
         {
             /*
@@ -99,6 +102,17 @@ namespace Octopus.Versioning
                 releaseLabels,
                 metadata,
                 originalVersion);
+        }
+
+        public static IVersion CreateDockerTag(string input)
+        {
+            return new DockerTag(input);
+        }
+
+        public static bool TryCreateDockerTag(string input, out IVersion version)
+        {
+            version = new DockerTag(input);
+            return true;
         }
     }
 }

--- a/source/Octopus.Versioning/VersionFormat.cs
+++ b/source/Octopus.Versioning/VersionFormat.cs
@@ -3,6 +3,7 @@
     public enum VersionFormat
     {
         Semver,
-        Maven
+        Maven,
+        Docker
     }
 }


### PR DESCRIPTION
Docker tags don't really fit the IVersion abstraction so this is a bit ugly. May need to rethink how we do versions to accomodate things other than SemVer.