### PR TITLE
Relaxed validation

### DIFF
--- a/source/Octopus.Versioning.Tests/Maven/MavenCoordinateTests.cs
+++ b/source/Octopus.Versioning.Tests/Maven/MavenCoordinateTests.cs
@@ -1,0 +1,70 @@
+﻿using NUnit.Framework;
+using Octopus.Versioning.Maven;
+
+namespace Octopus.Versioning.Tests.Versions
+{
+    [TestFixture]
+    public class MavenCoordinateTests
+    {
+        [Test]
+        public void GroupAndArtifactCoordinatesAreParsed()
+        {
+            var mavenId = new MavenPackageID("group:artifact");
+            Assert.AreEqual("group", mavenId.Group);
+            Assert.AreEqual("artifact", mavenId.Artifact);
+        }
+        
+        [Test]
+        public void GavCoordinatesAreParsed()
+        {
+            var mavenId = new MavenPackageID("group:artifact:version");
+            Assert.AreEqual("group", mavenId.Group);
+            Assert.AreEqual("artifact", mavenId.Artifact);
+            Assert.AreEqual("version", mavenId.Version);
+        }
+        
+        [Test]
+        public void GavWithPackagingCoordinatesAreParsed()
+        {
+            var mavenId = new MavenPackageID("group:artifact:version:packaging");
+            Assert.AreEqual("group", mavenId.Group);
+            Assert.AreEqual("artifact", mavenId.Artifact);
+            Assert.AreEqual("version", mavenId.Version);
+            Assert.AreEqual("packaging", mavenId.Packaging);
+        }
+        
+        [Test]
+        public void GavWithPackagingAndClassifierCoordinatesAreParsed()
+        {
+            var mavenId = new MavenPackageID("group:artifact:version:packaging:classifier");
+            Assert.AreEqual("group", mavenId.Group);
+            Assert.AreEqual("artifact", mavenId.Artifact);
+            Assert.AreEqual("version", mavenId.Version);
+            Assert.AreEqual("packaging", mavenId.Packaging);
+            Assert.AreEqual("classifier", mavenId.Classifier);
+        }
+        
+        /// <summary>
+        /// This test is an example of the non-standard group:artifact:packaging format used by
+        /// Octopus because versions are not supplied when selecting a package.
+        /// </summary>
+        [Test]
+        public void OctopusSpecificCoordinatesAreParsed()
+        {
+            var mavenId = MavenPackageID.CreatePackageIdFromOctopusInput("group:artifact:packaging");
+            Assert.AreEqual("group", mavenId.Group);
+            Assert.AreEqual("artifact", mavenId.Artifact);
+            Assert.AreEqual("packaging", mavenId.Packaging);
+        }
+        
+        [Test]
+        public void OctopusSpecificCoordinatesWithVersionAreParsed()
+        {
+            var mavenId = MavenPackageID.CreatePackageIdFromOctopusInput("group:artifact:packaging", new MavenVersionParser().Parse("1.0.0"));
+            Assert.AreEqual("group", mavenId.Group);
+            Assert.AreEqual("artifact", mavenId.Artifact);
+            Assert.AreEqual("packaging", mavenId.Packaging);
+            Assert.AreEqual("1.0.0", mavenId.Version);
+        }
+    }
+}

--- a/source/Octopus.Versioning/Maven/MavenPackageID.cs
+++ b/source/Octopus.Versioning/Maven/MavenPackageID.cs
@@ -27,7 +27,9 @@ namespace Octopus.Versioning.Maven
     {
         /// <summary>
         /// Standard GAV coordinates are group:artifact:version. This can also be extended to include the packaging in the
-        /// format group:artifact:version:packaging.
+        /// format group:artifact:version:packaging or group:artifact:version:packaging:classifier. See
+        /// http://maven.apache.org/plugins/maven-dependency-plugin/get-mojo.html for this format defined in the Maven
+        /// documentation.
         ///
         /// However, we never pass the version in the package id from the UI. Instead we pass a string like group:artifact or
         /// group:artifact:packaging. This is because the version selection is a separate process from the package definition.

--- a/source/Octopus.Versioning/Maven/MavenPackageID.cs
+++ b/source/Octopus.Versioning/Maven/MavenPackageID.cs
@@ -301,18 +301,18 @@ namespace Octopus.Versioning.Maven
 
                 if (mavenDisplaySplit.Length == 3) // groupId:artifactId:version
                 {
-                    Version = mavenDisplaySplit[2].Trim();
+                    Version = string.IsNullOrWhiteSpace(mavenDisplaySplit[2]) ? null : mavenDisplaySplit[2].Trim();
                 }
                 else if (mavenDisplaySplit.Length == 4) // groupId:artifactId:packaging:version
                 {
-                    Packaging = mavenDisplaySplit[2].Trim();
-                    Version = mavenDisplaySplit[3].Trim();
+                    Packaging = string.IsNullOrWhiteSpace(mavenDisplaySplit[2]) ? null : mavenDisplaySplit[2].Trim();
+                    Version = string.IsNullOrWhiteSpace(mavenDisplaySplit[3]) ? null : mavenDisplaySplit[3].Trim();
                 }
                 else if (mavenDisplaySplit.Length == 5) // groupId:artifactId:packaging:classifier:version
                 {
-                    Packaging = mavenDisplaySplit[2].Trim();
-                    Classifier = mavenDisplaySplit[3].Trim();
-                    Version = mavenDisplaySplit[4].Trim();
+                    Packaging = string.IsNullOrWhiteSpace(mavenDisplaySplit[2]) ? null : mavenDisplaySplit[2].Trim();
+                    Classifier = string.IsNullOrWhiteSpace(mavenDisplaySplit[3]) ? null : mavenDisplaySplit[3].Trim();
+                    Version = string.IsNullOrWhiteSpace(mavenDisplaySplit[4]) ? null : mavenDisplaySplit[4].Trim();
                 }
             }
             else

--- a/source/Octopus.Versioning/Maven/MavenPackageID.cs
+++ b/source/Octopus.Versioning/Maven/MavenPackageID.cs
@@ -294,7 +294,7 @@ namespace Octopus.Versioning.Maven
              * When downloading for the first time, we will use the G:A:V format
              * supplied by the end user.
              */
-            if (mavenDisplaySplit.Length >= 2 && mavenDisplaySplit.All(x => x != null && x.Trim().Length != 0))
+            if (mavenDisplaySplit.Length >= 2)
             {
                 Group = mavenDisplaySplit[0].Trim();
                 Artifact = mavenDisplaySplit[1].Trim();

--- a/source/Octopus.Versioning/Maven/MavenPackageID.cs
+++ b/source/Octopus.Versioning/Maven/MavenPackageID.cs
@@ -310,7 +310,7 @@ namespace Octopus.Versioning.Maven
 
         public MavenPackageID(string id, IVersion version) : this(id)
         {
-            if (id == null || id.Trim().Length == 0 || id.Split(':').Length != 2)
+            if (string.IsNullOrWhiteSpace(id) || id.Split(':').Length != 2)
             {
                 throw new ArgumentException("Package ID must be in the format Group:Artifact e.g. com.google.guava:guava or junit:junit.");
             }

--- a/source/Octopus.Versioning/Maven/MavenPackageID.cs
+++ b/source/Octopus.Versioning/Maven/MavenPackageID.cs
@@ -272,7 +272,7 @@ namespace Octopus.Versioning.Maven
 
         public MavenPackageID(string id, IVersion version) : this(id)
         {
-            Version = version.ToString();
+            Version = version?.ToString();
         }
 
         /// <summary>

--- a/source/Octopus.Versioning/Maven/MavenPackageID.cs
+++ b/source/Octopus.Versioning/Maven/MavenPackageID.cs
@@ -25,6 +25,30 @@ namespace Octopus.Versioning.Maven
     public class MavenPackageID
     {
         /// <summary>
+        /// Standard GAV coordinates are group:artifact:version. This can also be extended to include the packaging in the
+        /// format group:artifact:packaging:version.
+        ///
+        /// However, we never pass the version in the package id from the UI. Instead we pass a string like group:artifact or
+        /// group:artifact:packaging. This is because the version selection is a separate process from the package definition.
+        ///
+        /// It is here that we convert the package id sent from the UI into the standard Maven string.
+        /// </summary>
+        /// <param name="input">The input sent from the UI</param>
+        /// <param name="version">The optional version</param>
+        /// <returns>A MavenPackageID created to match the package id an optional packaging defined in the UI</returns>
+        /// <exception cref="ArgumentException">thrown if the input is not in the correct format</exception>
+        public static MavenPackageID CreatePackageIDFromUIInput(string input, IVersion version = null)
+        {
+            var splitVersion = input.Split(':').ToList();
+            if (!(splitVersion.Count == 2 || splitVersion.Count == 3))
+            {
+                throw new ArgumentException("Package ID must be in the format Group:Artifact e.g. com.google.guava:guava or junit:junit.");
+            }
+            splitVersion.Add(version != null ? version.ToString() : "");
+            return new MavenPackageID(string.Join(":", splitVersion));
+        }
+        
+        /// <summary>
         /// When we display the package ID to the user, this is the delimiter we use.
         /// The colon is the standard delimiter format for Maven packages, but it
         /// is not a valid file system character so we don't use it when saving


### PR DESCRIPTION
In order to allow the maven packaging type to be parsed in the coordinates without specifying a version, the validation had to be relaxed and a new factory method added to convert the non standard coords sent by the UI.