### PR TITLE
Fixed up comparasions of prerelease strings

### DIFF
--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using Octopus.Versioning.Octopus;
+using Octopus.Versioning.Semver;
 
 namespace Octopus.Versioning.Tests.Octopus
 {
@@ -54,6 +55,61 @@ namespace Octopus.Versioning.Tests.Octopus
         public void TestVersionComparisons(string version1, string version2, int result)
         {
             Assert.AreEqual(result, OctopusVersionParser.Parse(version1).CompareTo(OctopusVersionParser.Parse(version2)));
+        }
+
+        /// <summary>
+        /// This test validates the prerelease rules shown on https://semver.org/.
+        /// It verifies that valid semver versions compare in the same way with
+        /// the generic octopus version.
+        /// </summary>
+        [Test]
+        [TestCase("1.0.0-test.1", "1.0.0-test.2")]
+        [TestCase("1.0.0-alpha", "1.0.0-alpha.1" )]
+        [TestCase("1.0.0-alpha.1", "1.0.0-alpha.beta" )]
+        [TestCase("1.0.0-alpha.beta", "1.0.0-beta" )]
+        [TestCase("1.0.0-beta", "1.0.0-beta.2")]
+        [TestCase("1.0.0-beta.2", "1.0.0-beta.11")]
+        [TestCase("1.0.0-beta.11", "1.0.0-rc.1")]
+        [TestCase("1.0.0-rc.1", "1.0.0")]
+        public void TestSemverCompare(string version1, string version2)
+        {
+            var semver1 = SemVerFactory.CreateVersionOrNone(version1);
+            var semver2 = SemVerFactory.CreateVersionOrNone(version2);
+            
+            Assert.LessOrEqual(semver1.CompareTo(semver2), -1);
+
+            var octopus1 = OctopusVersionParser.Parse(version1);
+            var octopus2 = OctopusVersionParser.Parse(version2);
+            
+            Assert.LessOrEqual(octopus1.CompareTo(octopus2), -1);
+
+        }
+        
+        /// <summary>
+        /// Like the TestSemverCompare above, but allowing splits on underscores
+        /// and dashes.
+        /// </summary>
+        [Test]
+        [TestCase("1.0.0-test.1", "1.0.0-test-2")]
+        [TestCase("1.0.0-test.1", "1.0.0-test_2")]
+        [TestCase("1.0.0-test-1", "1.0.0-test-2")]
+        [TestCase("1.0.0-test-1", "1.0.0-test_2")]
+        [TestCase("1.0.0-test_1", "1.0.0-test-2")]
+        [TestCase("1.0.0-test_1", "1.0.0-test_2")]
+        [TestCase("1.0.0-alpha", "1.0.0-alpha_1" )]
+        [TestCase("1.0.0-beta.2", "1.0.0-beta-11")]
+        [TestCase("1.0.0-beta.2", "1.0.0-beta_11")]
+        [TestCase("1.0.0-beta-2", "1.0.0-beta-11")]
+        [TestCase("1.0.0-beta-2", "1.0.0-beta_11")]
+        [TestCase("1.0.0-beta_2", "1.0.0-beta-11")]
+        [TestCase("1.0.0-beta_2", "1.0.0-beta_11")]
+        public void TestOctopusPrereleaseCompare(string version1, string version2)
+        {
+            var octopus1 = OctopusVersionParser.Parse(version1);
+            var octopus2 = OctopusVersionParser.Parse(version2);
+            
+            Assert.LessOrEqual(octopus1.CompareTo(octopus2), -1);
+
         }
 
         [Test]


### PR DESCRIPTION
This change ensures that generic versions compare the individual components of a prerelease label in much the same way the semver did. 