### PR TITLE
Ints to longs

### DIFF
--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -13,6 +13,16 @@ namespace Octopus.Versioning.Tests.Octopus
         static readonly Random Random = new Random();
         static readonly OctopusVersionParser OctopusVersionParser = new OctopusVersionParser();
 
+        [TestCase("20210201130629.0.0.0")]
+        [TestCase("1.20210201130629.0.0")]
+        [TestCase("1.0.20210201130629.0")]
+        [TestCase("1.0.0.20210201130629")]
+        [TestCase("1.0.6765-20210201130629+master-49389e57")]
+        public void TestLongVersions(string version)
+        {
+            Assert.IsTrue(OctopusVersionParser.TryParse(version, out _));
+        }
+        
         [Test]
         public void TryParseTest()
         {

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -1014,11 +1014,11 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
-        [TestCase("2147483648.1.1")]
-        [TestCase("1.2147483648.1")]
-        [TestCase("1.1.2147483648")]
-        [TestCase("1.1.1.2147483648")]
-        [TestCase("1.1.9999999999")]
+        [TestCase("9223372036854775808.1.1")]
+        [TestCase("1.9223372036854775808.1")]
+        [TestCase("1.1.9223372036854775808")]
+        [TestCase("1.1.1.9223372036854775808")]
+        [TestCase("1.1.9223372036854775808")]
         public void LargeVersionNumbersWillFail(string version)
         {
             try

--- a/source/Octopus.Versioning/Docker/DockerTag.cs
+++ b/source/Octopus.Versioning/Docker/DockerTag.cs
@@ -43,10 +43,10 @@ namespace Octopus.Versioning.Docker
         {
         }
 
-        public override int Major => IsLatest ? int.MaxValue : base.Major;
-        public override int Minor => IsLatest ? int.MaxValue : base.Minor;
-        public override int Patch => IsLatest ? int.MaxValue : base.Patch;
-        public override int Revision => IsLatest ? int.MaxValue : base.Revision;
+        public override long Major => IsLatest ? long.MaxValue : base.Major;
+        public override long Minor => IsLatest ? long.MaxValue : base.Minor;
+        public override long Patch => IsLatest ? long.MaxValue : base.Patch;
+        public override long Revision => IsLatest ? long.MaxValue : base.Revision;
 
         bool IsLatest => base.Major == 0 &&
             base.Minor == 0 &&

--- a/source/Octopus.Versioning/IVersion.cs
+++ b/source/Octopus.Versioning/IVersion.cs
@@ -29,10 +29,10 @@ namespace Octopus.Versioning
     /// </summary>
     public interface IVersion : IComparable
     {
-        int Major { get; }
-        int Minor { get; }
-        int Patch { get; }
-        int Revision { get; }
+        long Major { get; }
+        long Minor { get; }
+        long Patch { get; }
+        long Revision { get; }
         bool IsPrerelease { get; }
         IEnumerable<string> ReleaseLabels { get; }
         string? Metadata { get; }

--- a/source/Octopus.Versioning/Maven/MavenVersion.cs
+++ b/source/Octopus.Versioning/Maven/MavenVersion.cs
@@ -80,10 +80,10 @@ namespace Octopus.Versioning.Maven
         {
             unchecked
             {
-                var hashCode = (int)Major;
-                hashCode = (hashCode * 397) ^ (int)Minor;
-                hashCode = (hashCode * 397) ^ (int)Patch;
-                hashCode = (hashCode * 397) ^ (int)Revision;
+                var hashCode = Major;
+                hashCode = (hashCode * 397) ^ Minor;
+                hashCode = (hashCode * 397) ^ Patch;
+                hashCode = (hashCode * 397) ^ Revision;
                 hashCode = (hashCode * 397) ^ (ReleaseLabels != null ? ReleaseLabels.GetHashCode() : 0);
                 return (int)hashCode;
             }

--- a/source/Octopus.Versioning/Maven/MavenVersion.cs
+++ b/source/Octopus.Versioning/Maven/MavenVersion.cs
@@ -22,10 +22,10 @@ namespace Octopus.Versioning.Maven
             OriginalString = originalVersion;
         }
 
-        public int Major { get; }
-        public int Minor { get; }
-        public int Patch { get; }
-        public int Revision { get; }
+        public long Major { get; }
+        public long Minor { get; }
+        public long Patch { get; }
+        public long Revision { get; }
 
         public bool IsPrerelease => ReleaseLabels.Any(label =>
         {
@@ -80,10 +80,10 @@ namespace Octopus.Versioning.Maven
         {
             unchecked
             {
-                var hashCode = Major;
-                hashCode = (hashCode * 397) ^ Minor;
-                hashCode = (hashCode * 397) ^ Patch;
-                hashCode = (hashCode * 397) ^ Revision;
+                var hashCode = (int)Major;
+                hashCode = (hashCode * 397) ^ (int)Minor;
+                hashCode = (hashCode * 397) ^ (int)Patch;
+                hashCode = (hashCode * 397) ^ (int)Revision;
                 hashCode = (hashCode * 397) ^ (ReleaseLabels != null ? ReleaseLabels.GetHashCode() : 0);
                 return (int)hashCode;
             }

--- a/source/Octopus.Versioning/Octopus/OctopusVersion.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersion.cs
@@ -7,10 +7,10 @@ namespace Octopus.Versioning.Octopus
     public class OctopusVersion : IVersion
     {
         public OctopusVersion(string? prefix,
-            int major,
-            int minor,
-            int patch,
-            int revision,
+            long major,
+            long minor,
+            long patch,
+            long revision,
             string? prerelease,
             string? prereleasePrefix,
             string? prereleaseCounter,
@@ -30,10 +30,10 @@ namespace Octopus.Versioning.Octopus
         }
 
         public virtual string Prefix { get; }
-        public virtual int Major { get; }
-        public virtual int Minor { get; }
-        public virtual int Patch { get; }
-        public virtual int Revision { get; }
+        public virtual long Major { get; }
+        public virtual long Minor { get; }
+        public virtual long Patch { get; }
+        public virtual long Revision { get; }
         public virtual bool IsPrerelease => !string.IsNullOrEmpty(Release);
         public virtual IEnumerable<string> ReleaseLabels => Enumerable.Empty<string>();
         public virtual string Metadata { get; }

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -38,10 +38,10 @@ namespace Octopus.Versioning.Octopus
                 var result = VersionRegex.Match(version?.Trim() ?? string.Empty);
                 return new OctopusVersion(
                     result.Groups[Prefix].Success ? result.Groups[Prefix].Value : string.Empty,
-                    result.Groups[Major].Success ? int.Parse(result.Groups[Major].Value) : 0,
-                    result.Groups[Minor].Success ? int.Parse(result.Groups[Minor].Value) : 0,
-                    result.Groups[Patch].Success ? int.Parse(result.Groups[Patch].Value) : 0,
-                    result.Groups[Revision].Success ? int.Parse(result.Groups[Revision].Value) : 0,
+                    result.Groups[Major].Success ? long.Parse(result.Groups[Major].Value) : 0,
+                    result.Groups[Minor].Success ? long.Parse(result.Groups[Minor].Value) : 0,
+                    result.Groups[Patch].Success ? long.Parse(result.Groups[Patch].Value) : 0,
+                    result.Groups[Revision].Success ? long.Parse(result.Groups[Revision].Value) : 0,
                     result.Groups[Prerelease].Success ? result.Groups[Prerelease].Value : string.Empty,
                     result.Groups[PrereleasePrefix].Success ? result.Groups[PrereleasePrefix].Value : string.Empty,
                     result.Groups[PrereleaseCounter].Success ? result.Groups[PrereleaseCounter].Value : string.Empty,

--- a/source/Octopus.Versioning/Semver/SemVerFactory.cs
+++ b/source/Octopus.Versioning/Semver/SemVerFactory.cs
@@ -105,10 +105,12 @@ namespace Octopus.Versioning.Semver
         public static SemanticVersion? TryParseStrict(string value)
         {
             var semVer = TryCreateVersion(value);
+            
+            // Convert.ToInt32() will not throw, because semver versions only parse ints
             return semVer != null
-                ? new SemanticVersion((int)semVer.Major,
-                    (int)semVer.Minor,
-                    (int)semVer.Patch,
+                ? new SemanticVersion(Convert.ToInt32(semVer.Major),
+                    Convert.ToInt32(semVer.Minor),
+                    Convert.ToInt32(semVer.Patch),
                     0,
                     semVer.ReleaseLabels,
                     semVer.Metadata)

--- a/source/Octopus.Versioning/Semver/SemVerFactory.cs
+++ b/source/Octopus.Versioning/Semver/SemVerFactory.cs
@@ -106,9 +106,9 @@ namespace Octopus.Versioning.Semver
         {
             var semVer = TryCreateVersion(value);
             return semVer != null
-                ? new SemanticVersion(semVer.Major,
-                    semVer.Minor,
-                    semVer.Patch,
+                ? new SemanticVersion((int)semVer.Major,
+                    (int)semVer.Minor,
+                    (int)semVer.Patch,
                     0,
                     semVer.ReleaseLabels,
                     semVer.Metadata)

--- a/source/Octopus.Versioning/Semver/StrictSemanticVersion.cs
+++ b/source/Octopus.Versioning/Semver/StrictSemanticVersion.cs
@@ -67,22 +67,22 @@ namespace Octopus.Versioning.Semver
         /// <summary>
         /// Major version X (X.y.z)
         /// </summary>
-        public int Major => version.Major;
+        public long Major => version.Major;
 
         /// <summary>
         /// Minor version Y (x.Y.z)
         /// </summary>
-        public int Minor => version.Minor;
+        public long Minor => version.Minor;
 
         /// <summary>
         /// Patch version Z (x.y.Z)
         /// </summary>
-        public int Patch => version.Build;
+        public long Patch => version.Build;
 
         /// <summary>
         /// Revision version R (x.y.z.R)
         /// </summary>
-        public int Revision => version.Revision;
+        public long Revision => version.Revision;
 
         /// <summary>
         /// A collection of pre-release labels attached to the version.


### PR DESCRIPTION
This change extends the range of version fields to fix issues like https://help.octopus.com/t/cant-deploy-because-of-package-versioning-validation-error/26242.