### PR TITLE
Long version fields

### DIFF
--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
@@ -66,6 +66,9 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase("1.0.0+meta", "1.0.0+meta", 0)]
         [TestCase("1.0.0+meta1", "1.0.0+meta2", 0)]
         [TestCase("1.0.0+meta3", "1.0.0+meta2", 0)]
+        [TestCase("1.0.0.99999999999999999999999999999", "1.0.0.888888888888888888888888888", 1)]
+        [TestCase("1.0.0-99999999999999999999999999999", "1.0.0-888888888888888888888888888", 1)]
+        [TestCase("1.0.0_99999999999999999999999999999", "1.0.0_888888888888888888888888888", 1)]
         public void TestVersionComparisons(string version1, string version2, int result)
         {
             Assert.AreEqual(result, OctopusVersionParser.Parse(version1).CompareTo(OctopusVersionParser.Parse(version2)));

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -21,6 +21,15 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
+        [TestCase("1.0.6765-20210201130629+master-49389e57",
+            1,
+            0,
+            6765,
+            0,
+            "20210201130629",
+            "20210201130629",
+            "",
+            "master-49389e57")]       
         [TestCase("0.0.4",
             0,
             0,

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -16,7 +16,7 @@ namespace Octopus.Versioning.Tests.Octopus
         [Test]
         public void TryParseTest()
         {
-            Assert.IsFalse(OctopusVersionParser.TryParse("99999999999999999999999999999999999", out var version));
+            Assert.IsTrue(OctopusVersionParser.TryParse("99999999999999999999999999999999999", out var version));
             Assert.IsTrue(OctopusVersionParser.TryParse("1.1.1.1", out var version2));
         }
 
@@ -1004,22 +1004,16 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
-        [TestCase("2147483648.1.1")]
-        [TestCase("1.2147483648.1")]
-        [TestCase("1.1.2147483648")]
-        [TestCase("1.1.1.2147483648")]
-        [TestCase("1.1.9999999999")]
-        public void LargeVersionNumbersWillFail(string version)
+        [TestCase("2147483648.1.1", "2147483648.1.1")]
+        [TestCase("1.2147483648.1", "2147483648.1")]
+        [TestCase("1.1.2147483648", "2147483648")]
+        [TestCase("1.1.1.2147483648", "2147483648")]
+        [TestCase("1.1.9999999999", "9999999999")]
+        public void LargeVersionNumbersWillBeTreatedAsPrereleases(string version, string prerelease)
         {
-            try
-            {
-                OctopusVersionParser.Parse(version);
-                Assert.Fail("Should have thrown an exception");
-            }
-            catch (OverflowException)
-            {
-                Assert.Pass("Exception was expected");
-            }
+
+             var parsed = OctopusVersionParser.Parse(version);
+             Assert.AreEqual(prerelease, parsed.Release);
         }
 
         public static string RandomString(int length)

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -36,7 +36,6 @@ namespace Octopus.Versioning.Octopus
 
         public OctopusVersion Parse(string? version)
         {
-
             var result = VersionRegex.Match(version?.Trim() ?? string.Empty);
                             // Version numbers must be ints
             bool majorIsInt = result.Groups[Major].Success && int.TryParse(result.Groups[Major].Value, out _);
@@ -44,7 +43,9 @@ namespace Octopus.Versioning.Octopus
             bool patchIsInt = minorIsInt && result.Groups[Patch].Success && int.TryParse(result.Groups[Patch].Value, out _);
             bool revisionIsInt = patchIsInt && result.Groups[Revision].Success && int.TryParse(result.Groups[Revision].Value, out _);
 
-            // The first field that isn't an int marks the beginning of the prerelease
+            // The first field that isn't an int marks the beginning of the prerelease. This accounts
+            // for versions that place things like timestamps into a field like
+            // 1.0.6765-20210201130629+master-49389e57.
             var fieldPreRelease = "";
             if (!revisionIsInt) fieldPreRelease = result.Groups[Revision].Value;
             if (!patchIsInt) fieldPreRelease = result.Groups[Patch].Value + result.Groups[RevisionGroup].Value;

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -8,8 +8,11 @@ namespace Octopus.Versioning.Octopus
         const string Prefix = "prefix";
         const string Major = "major";
         const string Minor = "minor";
+        const string MinorGroup = "minorgroup";
         const string Patch = "patch";
+        const string PatchGroup = "patchgroup";
         const string Revision = "revision";
+        const string RevisionGroup = "revisiongroup";
         const string Prerelease = "prerelease";
         const string PrereleasePrefix = "prereleaseprefix";
         const string PrereleaseCounter = "prereleasecounter";
@@ -21,11 +24,11 @@ namespace Octopus.Versioning.Octopus
             // Get the major version number
             @$"(?<{Major}>\d+)" +
             // Get the minor version number, delimited by a period, comma, dash or underscore
-            @$"(?:[.\-_](?<{Minor}>\d+))?" +
+            @$"(?<{MinorGroup}>[.\-_](?<{Minor}>\d+))?" +
             // Get the patch version number, delimited by a period, comma, dash or underscore
-            @$"(?:[.\-_](?<{Patch}>\d+))?" +
+            @$"(?<{PatchGroup}>[.\-_](?<{Patch}>\d+))?" +
             // Get the revision version number, delimited by a period, comma, dash or underscore
-            @$"(?:[.\-_](?<{Revision}>\d+))?)?" +
+            @$"(?<{RevisionGroup}>[.\-_](?<{Revision}>\d+))?)?" +
             // Everything after the last digit and before the plus is the prerelease
             @$"(?:[.\-_])?(?<{Prerelease}>(?<{PrereleasePrefix}>[^+.\-_\s]*?)([.\-_](?<{PrereleaseCounter}>[^+\s]*?)?)?)?" +
             // The metadata is everything after the plus
@@ -33,26 +36,34 @@ namespace Octopus.Versioning.Octopus
 
         public OctopusVersion Parse(string? version)
         {
-            try
-            {
-                var result = VersionRegex.Match(version?.Trim() ?? string.Empty);
-                return new OctopusVersion(
-                    result.Groups[Prefix].Success ? result.Groups[Prefix].Value : string.Empty,
-                    result.Groups[Major].Success ? int.Parse(result.Groups[Major].Value) : 0,
-                    result.Groups[Minor].Success ? int.Parse(result.Groups[Minor].Value) : 0,
-                    result.Groups[Patch].Success ? int.Parse(result.Groups[Patch].Value) : 0,
-                    result.Groups[Revision].Success ? int.Parse(result.Groups[Revision].Value) : 0,
-                    result.Groups[Prerelease].Success ? result.Groups[Prerelease].Value : string.Empty,
-                    result.Groups[PrereleasePrefix].Success ? result.Groups[PrereleasePrefix].Value : string.Empty,
-                    result.Groups[PrereleaseCounter].Success ? result.Groups[PrereleaseCounter].Value : string.Empty,
-                    result.Groups[Meta].Success ? result.Groups[Meta].Value : string.Empty,
-                    version ?? string.Empty);
-            }
-            catch (OverflowException ex)
-            {
-                throw new OverflowException($"Failed to parse the version {version?.Trim()} because the major, minor, patch or revision fields were too large.", ex);
-            }
-        }
+
+            var result = VersionRegex.Match(version?.Trim() ?? string.Empty);
+                            // Version numbers must be ints
+            bool majorIsInt = result.Groups[Major].Success && int.TryParse(result.Groups[Major].Value, out _);
+            bool minorIsInt = majorIsInt && result.Groups[Minor].Success && int.TryParse(result.Groups[Minor].Value, out _);
+            bool patchIsInt = minorIsInt && result.Groups[Patch].Success && int.TryParse(result.Groups[Patch].Value, out _);
+            bool revisionIsInt = patchIsInt && result.Groups[Revision].Success && int.TryParse(result.Groups[Revision].Value, out _);
+
+            // The first field that isn't an int marks the beginning of the prerelease
+            var fieldPreRelease = "";
+            if (!revisionIsInt) fieldPreRelease = result.Groups[Revision].Value;
+            if (!patchIsInt) fieldPreRelease = result.Groups[Patch].Value + result.Groups[RevisionGroup].Value;
+            if (!minorIsInt) fieldPreRelease = result.Groups[Minor].Value + result.Groups[PatchGroup].Value + result.Groups[RevisionGroup].Value;
+            if (!majorIsInt) fieldPreRelease = result.Groups[Major].Value + result.Groups[MinorGroup].Value + result.Groups[PatchGroup].Value + result.Groups[RevisionGroup].Value;
+
+            return new OctopusVersion(
+                string.Empty,
+                majorIsInt ? int.Parse(result.Groups[Major].Value) : 0,
+                minorIsInt ? int.Parse(result.Groups[Minor].Value) : 0,
+                patchIsInt ? int.Parse(result.Groups[Patch].Value) : 0,
+                revisionIsInt ? int.Parse(result.Groups[Revision].Value) : 0,
+                fieldPreRelease + (result.Groups[Prerelease].Success ? result.Groups[Prerelease].Value : string.Empty),
+                fieldPreRelease + (result.Groups[PrereleasePrefix].Success ? result.Groups[PrereleasePrefix].Value : string.Empty),
+                result.Groups[PrereleaseCounter].Success ? result.Groups[PrereleaseCounter].Value : string.Empty,
+                result.Groups[Meta].Success ? result.Groups[Meta].Value : string.Empty,
+                version);
+            
+    }
 
         public bool TryParse(string version, out OctopusVersion parsedVersion)
         {


### PR DESCRIPTION
This change extends the range of version fields to fix issues like https://help.octopus.com/t/cant-deploy-because-of-package-versioning-validation-error/26242.