### PR TITLE
Excluded some tricky characters

### DIFF
--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
@@ -108,9 +108,9 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
-        [TestCase("1.1.1-prerelease!@#$^&*()[]{};':\",.<>?", "1.1.1-prerelease][)(*&^$#@!{};':\",.<>?", 0, Description = "Non alphanumeric chars compare the same")]
+        [TestCase("1.1.1-prerelease!@$^*()[]{};':\",.<>", "1.1.1-prerelease][)(*^$@!{};':\",.<>", 0, Description = "Non alphanumeric chars compare the same")]
         [TestCase("1.1.1-大きい", "1.1.1_小さい", -1, Description = "UTF chars have meaning")]
-        [TestCase("1.1.1-!@#.10", "1.1.1.#@!.11", -1, Description = "prerelease tags are compared")]
+        [TestCase("1.1.1-!@.10", "1.1.1.@!.11", -1, Description = "prerelease tags are compared")]
         public void CompareVersionsWithEquivalentChars(string version1, string version2, int expected)
         {
             var result = OctopusVersionParser.Parse(version1).CompareTo(OctopusVersionParser.Parse(version2));

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
@@ -108,9 +108,8 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
-        [TestCase("1.1.1-prerelease!@$^*()[]{};':\",.<>", "1.1.1-prerelease][)(*^$@!{};':\",.<>", 0, Description = "Non alphanumeric chars compare the same")]
-        [TestCase("1.1.1-大きい", "1.1.1_小さい", -1, Description = "UTF chars have meaning")]
-        [TestCase("1.1.1-!@.10", "1.1.1.@!.11", -1, Description = "prerelease tags are compared")]
+        [TestCase("1.1.1-prerelease_-.\\", "1.1.1-prerelease\\.-_", 0, Description = "Non alphanumeric chars compare the same")]
+        [TestCase("1.1.1-\\_.10", "1.1.1._\\.11", -1, Description = "prerelease tags are compared")]
         public void CompareVersionsWithEquivalentChars(string version1, string version2, int expected)
         {
             var result = OctopusVersionParser.Parse(version1).CompareTo(OctopusVersionParser.Parse(version2));

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
@@ -108,7 +108,7 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
-        [TestCase("1.1.1-prerelease!@#$%^&*()[]{};':\",./<>?", "1.1.1-prerelease][)(*&^%$#@!{};':\",./<>?", 0, Description = "Non alphanumeric chars compare the same")]
+        [TestCase("1.1.1-prerelease!@#$^&*()[]{};':\",.<>?", "1.1.1-prerelease][)(*&^$#@!{};':\",.<>?", 0, Description = "Non alphanumeric chars compare the same")]
         [TestCase("1.1.1-大きい", "1.1.1_小さい", -1, Description = "UTF chars have meaning")]
         [TestCase("1.1.1-!@#.10", "1.1.1.#@!.11", -1, Description = "prerelease tags are compared")]
         public void CompareVersionsWithEquivalentChars(string version1, string version2, int expected)

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -962,9 +962,25 @@ namespace Octopus.Versioning.Tests.Octopus
             }
         }
 
+        [Test]
+        [TestCase("1.2.3-hi/there")]
+        [TestCase("1.2.3-hi%there")]
+        public void IllegalCharsWillFail(string version)
+        {
+            try
+            {
+                OctopusVersionParser.Parse(version);
+                Assert.Fail("Should have thrown an exception");
+            }
+            catch (Exception)
+            {
+                Assert.Pass("Exception was expected");
+            }
+        }
+
         public static string RandomString(int length)
         {
-            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()_+{}|:\"<>?-=[]\\;',./`~";
+            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$^&*()_+{}|:\"<>?-=[]\\;',.`~";
             return new string(Enumerable.Repeat(chars, length)
                 .Select(s => s[Random.Next(s.Length)])
                 .ToArray());

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -835,15 +835,6 @@ namespace Octopus.Versioning.Tests.Octopus
             "component_based",
             "",
             Description = "https://hub.docker.com/r/google/cloud-sdk/tags")]
-        [TestCase(null,
-            0,
-            0,
-            0,
-            0,
-            "",
-            "",
-            "",
-            "")]
         [TestCase("latest",
             0,
             0,

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -853,6 +853,15 @@ namespace Octopus.Versioning.Tests.Octopus
             "stable",
             "",
             "")]
+        [TestCase("stable-\\hi_there.how-are+you+today",
+            0,
+            0,
+            0,
+            0,
+            "stable-\\hi_there.how-are",
+            "stable",
+            "\\hi_there.how-are",
+            "you+today")]
         public void TestInvalidSemverVersions(string version,
             int major,
             int minor,

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -959,7 +959,7 @@ namespace Octopus.Versioning.Tests.Octopus
 
         public static string RandomString(int length)
         {
-            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@$^*()_+{}|:\"<>-=[]\\;',.`~";
+            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.\\+";
             return new string(Enumerable.Repeat(chars, length)
                 .Select(s => s[Random.Next(s.Length)])
                 .ToArray());

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -835,24 +835,6 @@ namespace Octopus.Versioning.Tests.Octopus
             "component_based",
             "",
             Description = "https://hub.docker.com/r/google/cloud-sdk/tags")]
-        [TestCase(" ",
-            0,
-            0,
-            0,
-            0,
-            "",
-            "",
-            "",
-            "")]
-        [TestCase("",
-            0,
-            0,
-            0,
-            0,
-            "",
-            "",
-            "",
-            "")]
         [TestCase(null,
             0,
             0,
@@ -965,6 +947,9 @@ namespace Octopus.Versioning.Tests.Octopus
         [Test]
         [TestCase("1.2.3-hi/there")]
         [TestCase("1.2.3-hi%there")]
+        [TestCase(" ")]
+        [TestCase("")]
+        [TestCase(null)]
         public void IllegalCharsWillFail(string version)
         {
             try

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -947,6 +947,9 @@ namespace Octopus.Versioning.Tests.Octopus
         [Test]
         [TestCase("1.2.3-hi/there")]
         [TestCase("1.2.3-hi%there")]
+        [TestCase("1.2.3-hi?there")]
+        [TestCase("1.2.3-hi#there")]
+        [TestCase("1.2.3-hi&there")]
         [TestCase(" ")]
         [TestCase("")]
         [TestCase(null)]
@@ -965,7 +968,7 @@ namespace Octopus.Versioning.Tests.Octopus
 
         public static string RandomString(int length)
         {
-            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$^&*()_+{}|:\"<>?-=[]\\;',.`~";
+            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@$^*()_+{}|:\"<>-=[]\\;',.`~";
             return new string(Enumerable.Repeat(chars, length)
                 .Select(s => s[Random.Next(s.Length)])
                 .ToArray());

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -41,12 +41,23 @@ namespace Octopus.Versioning.Octopus
         {
             try
             {
-                if (IllegalChars.Any(c => version?.Contains(c) ?? false))
+                if (version?.Trim() == string.Empty)
                 {
-                    throw new ArgumentException("The version contained one of the following illegal characters: " + string.Join(", ", IllegalChars));
+                    throw new ArgumentException("The version can not be an empty string");
                 }
 
-                var result = VersionRegex.Match(version?.Trim() ?? string.Empty);
+                if (version?.Contains(" ") ?? false)
+                {
+                    throw new ArgumentException("The version can not contain spaces");
+                }
+
+                if (IllegalChars.Any(c => version?.Contains(c) ?? false))
+                {
+                    throw new ArgumentException("The version contained one of the following characters: " + string.Join(", ", IllegalChars));
+                }
+
+                var result = VersionRegex.Match(version ?? string.Empty);
+
                 return new OctopusVersion(
                     result.Groups[Prefix].Success ? result.Groups[Prefix].Value : string.Empty,
                     result.Groups[Major].Success ? int.Parse(result.Groups[Major].Value) : 0,

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -33,9 +33,9 @@ namespace Octopus.Versioning.Octopus
             // Get the revision version number, delimited by a period, comma, dash or underscore
             @$"(?:\.(?<{Revision}>\d+))?)?" +
             // Everything after the last digit and before the plus is the prerelease
-            @$"(?:[.\-_])?(?<{Prerelease}>(?<{PrereleasePrefix}>[^+.\-_\s]*?)([.\-_](?<{PrereleaseCounter}>[^+\s]*?)?)?)?" +
+            @$"(?:[.\-_\\])?(?<{Prerelease}>(?<{PrereleasePrefix}>[A-Za-z0-9]*?)([.\-_\\](?<{PrereleaseCounter}>[A-Za-z0-9.\-_\\]*?)?)?)?" +
             // The metadata is everything after the plus
-            $@"(?:\+(?<{Meta}>[^\s]*?))?$");
+            $@"(?:\+(?<{Meta}>[A-Za-z0-9_\-.\\+]*?))?$");
 
         public OctopusVersion Parse(string? version)
         {
@@ -49,11 +49,6 @@ namespace Octopus.Versioning.Octopus
                 if (version?.Contains(" ") ?? false)
                 {
                     throw new ArgumentException("The version can not contain spaces");
-                }
-
-                if (IllegalChars.Any(c => version?.Contains(c) ?? false))
-                {
-                    throw new ArgumentException("The version contained one of the following characters: " + string.Join(", ", IllegalChars));
                 }
 
                 var result = VersionRegex.Match(version ?? string.Empty);

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -1,10 +1,16 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace Octopus.Versioning.Octopus
 {
     public class OctopusVersionParser
     {
+        /// <summary>
+        /// Versions can appear in URLs, and these characters are hard to work with in URLs, so we exclude them from any part of the version
+        /// </summary>
+        static readonly string[] IllegalChars = { "/", "%" };
+
         const string Prefix = "prefix";
         const string Major = "major";
         const string Minor = "minor";
@@ -35,6 +41,11 @@ namespace Octopus.Versioning.Octopus
         {
             try
             {
+                if (IllegalChars.Any(c => version?.Contains(c) ?? false))
+                {
+                    throw new ArgumentException("The version contained one of the following illegal characters: " + string.Join(", ", IllegalChars));
+                }
+
                 var result = VersionRegex.Match(version?.Trim() ?? string.Empty);
                 return new OctopusVersion(
                     result.Groups[Prefix].Success ? result.Groups[Prefix].Value : string.Empty,

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -9,7 +9,7 @@ namespace Octopus.Versioning.Octopus
         /// <summary>
         /// Versions can appear in URLs, and these characters are hard to work with in URLs, so we exclude them from any part of the version
         /// </summary>
-        static readonly string[] IllegalChars = { "/", "%" };
+        static readonly string[] IllegalChars = { "/", "%", "?", "#", "&" };
 
         const string Prefix = "prefix";
         const string Major = "major";

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -41,7 +41,7 @@ namespace Octopus.Versioning.Octopus
         {
             try
             {
-                if (version?.Trim() == string.Empty)
+                if ((version?.Trim() ?? string.Empty) == string.Empty)
                 {
                     throw new ArgumentException("The version can not be an empty string");
                 }


### PR DESCRIPTION
This change limits some characters that are likely to cause issues when a version is included in a URL to avoid any potential issues with the front end code.