### PR TITLE
Latest is no longer sorted any differently in docker tags

### DIFF
--- a/source/Octopus.Versioning.Tests/Docker/DockerVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Docker/DockerVersionCompareTests.cs
@@ -7,8 +7,8 @@ namespace Octopus.Versioning.Tests.Versions.Docker
     public class DockerVersionCompareTests
     {
         [Test]
-        [TestCase("latest", "1.0.0", 1)]
-        [TestCase("1.0.0", "latest", -1)]
+        [TestCase("latest", "1.0.0", -1)]
+        [TestCase("1.0.0", "latest", 1)]
         [TestCase("latest", "latest", 0)]
         public void TestLatestVersions(string version1, string version2, int result)
         {

--- a/source/Octopus.Versioning/Docker/DockerTag.cs
+++ b/source/Octopus.Versioning/Docker/DockerTag.cs
@@ -43,33 +43,8 @@ namespace Octopus.Versioning.Docker
         {
         }
 
-        public override int Major => IsLatest ? int.MaxValue : base.Major;
-        public override int Minor => IsLatest ? int.MaxValue : base.Minor;
-        public override int Patch => IsLatest ? int.MaxValue : base.Patch;
-        public override int Revision => IsLatest ? int.MaxValue : base.Revision;
-
-        bool IsLatest => base.Major == 0 &&
-            base.Minor == 0 &&
-            base.Patch == 0 &&
-            base.Revision == 0 &&
-            base.ReleasePrefix == Latest &&
-            string.IsNullOrEmpty(base.ReleaseCounter) &&
-            string.IsNullOrEmpty(base.Metadata);
-
         public override VersionFormat Format => VersionFormat.Docker;
 
         public override bool IsPrerelease => !string.IsNullOrEmpty(Release) && OriginalString != Latest;
-
-        public override int CompareTo(object obj)
-        {
-            if (obj is IVersion objVersion)
-            {
-                if (OriginalString == Latest && objVersion.OriginalString == Latest) return 0;
-                if (OriginalString == Latest) return 1;
-                if (objVersion.OriginalString == Latest) return -1;
-            }
-
-            return base.CompareTo(obj);
-        }
     }
 }


### PR DESCRIPTION
After some discussion around the semantics of the Docker latest tag, it was decided that it should not be sorted as the latest version. This PR changes the latest tag so it is no longer the latest available tag.