### PR TITLE
Tolerate leading and trailing whitespace when parsing versions

### DIFF
--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -1035,6 +1035,7 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase("1.2.3-hi&there")]
         [TestCase("1.2.3-hi there")]
         [TestCase("1.2.3-hithere +meta", Description = "Ensure prerelease spaces are treated the same way in OctopusVersionParser and SemVerFactory")]
+        [TestCase("1.2.3- hithere+meta", Description = "Ensure prerelease spaces are treated the same way in OctopusVersionParser and SemVerFactory")]
         [TestCase("1.2.3-hithere+ meta", Description = "Ensure metadata spaces are treated the same way in OctopusVersionParser and SemVerFactory")]
         [TestCase(" ")]
         [TestCase("")]

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -372,6 +372,33 @@ namespace Octopus.Versioning.Tests.Octopus
             "9999999999999999999999999",
             "",
             "")]
+        [TestCase(" 1.1.01-9999999999999999999999999",
+            1,
+            1,
+            1,
+            0,
+            "9999999999999999999999999",
+            "9999999999999999999999999",
+            "",
+            "")]
+        [TestCase("1.1.01-9999999999999999999999999 ",
+            1,
+            1,
+            1,
+            0,
+            "9999999999999999999999999",
+            "9999999999999999999999999",
+            "",
+            "")]
+        [TestCase(" 1.1.01-9999999999999999999999999 ",
+            1,
+            1,
+            1,
+            0,
+            "9999999999999999999999999",
+            "9999999999999999999999999",
+            "",
+            "")]
         public void TestSemverVersions(string version,
             int major,
             int minor,
@@ -862,6 +889,15 @@ namespace Octopus.Versioning.Tests.Octopus
             "stable",
             "\\hi_there.how-are",
             "you+today")]
+        [TestCase(" stable-\\hi_there.how-are+you+today ",
+            0,
+            0,
+            0,
+            0,
+            "stable-\\hi_there.how-are",
+            "stable",
+            "\\hi_there.how-are",
+            "you+today")]
         public void TestInvalidSemverVersions(string version,
             int major,
             int minor,
@@ -946,23 +982,25 @@ namespace Octopus.Versioning.Tests.Octopus
 
         [Test]
         [TestCase("1.2.3-hi/there")]
+        [TestCase(" 1.2.3-hi/there ")]
         [TestCase("1.2.3-hi%there")]
+        [TestCase(" 1.2.3-hi%there ")]
         [TestCase("1.2.3-hi?there")]
+        [TestCase(" 1.2.3-hi?there ")]
         [TestCase("1.2.3-hi#there")]
+        [TestCase(" 1.2.3-hi#there ")]
         [TestCase("1.2.3-hi&there")]
         [TestCase(" ")]
         [TestCase("")]
         [TestCase(null)]
         public void IllegalCharsWillFail(string version)
         {
-            try
+            var octoSuccess = OctopusVersionParser.TryParse(version, out _);
+            var semanticVersion = SemVerFactory.TryCreateVersion(version);
+
+            if (octoSuccess != false || semanticVersion != null)
             {
-                OctopusVersionParser.Parse(version);
                 Assert.Fail("Should have thrown an exception");
-            }
-            catch (ArgumentException)
-            {
-                Assert.Pass("Exception was expected");
             }
         }
 

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -1051,6 +1051,28 @@ namespace Octopus.Versioning.Tests.Octopus
             }
         }
 
+        /// <summary>
+        /// This test ensures the OriginalString value is the same whether parsed by OctopusVersionParser or
+        /// SemVerFactory
+        /// </summary>
+        /// <param name="version">The version to parse</param>
+        [Test]
+        [TestCase("1.2.3-hithere")]
+        [TestCase(" 1.2.3-hithere")]
+        [TestCase("1.2.3-hithere ")]
+        [TestCase(" 1.2.3-hithere ")]
+        [TestCase("1 .2.3-hithere")]
+        [TestCase("1. 2 .3-hithere")]
+        [TestCase("1.2. 3 -hithere")]
+        [TestCase("1.2.3. 1 -hithere")]
+        public void TestOriginalStringIsTheSame(string version)
+        {
+            OctopusVersionParser.TryParse(version, out var octoVersion);
+            var semanticVersion = SemVerFactory.TryCreateVersion(version);
+
+            Assert.AreEqual(octoVersion.OriginalString, semanticVersion.OriginalString);
+        }
+
         public static string RandomString(int length)
         {
             const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.\\+";

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -990,6 +990,7 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase("1.2.3-hi#there")]
         [TestCase(" 1.2.3-hi#there ")]
         [TestCase("1.2.3-hi&there")]
+        [TestCase("1.2.3-hi there")]
         [TestCase(" ")]
         [TestCase("")]
         [TestCase(null)]
@@ -998,7 +999,7 @@ namespace Octopus.Versioning.Tests.Octopus
             var octoSuccess = OctopusVersionParser.TryParse(version, out _);
             var semanticVersion = SemVerFactory.TryCreateVersion(version);
 
-            if (octoSuccess != false || semanticVersion != null)
+            if (octoSuccess || semanticVersion != null)
             {
                 Assert.Fail("Should have thrown an exception");
             }

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -372,7 +372,7 @@ namespace Octopus.Versioning.Tests.Octopus
             "9999999999999999999999999",
             "",
             "")]
-        [TestCase(" 1.1.01-9999999999999999999999999",
+        [TestCase("1.1.01-9999999999999999999999999+meta ",
             1,
             1,
             1,
@@ -380,7 +380,8 @@ namespace Octopus.Versioning.Tests.Octopus
             "9999999999999999999999999",
             "9999999999999999999999999",
             "",
-            "")]
+            "meta",
+            Description = "Test that trailing whitespace after metadata is treated the same way in SemVerFactory and OctopusVersionParser")]
         [TestCase("1.1.01-9999999999999999999999999 ",
             1,
             1,
@@ -389,7 +390,8 @@ namespace Octopus.Versioning.Tests.Octopus
             "9999999999999999999999999",
             "9999999999999999999999999",
             "",
-            "")]
+            "",
+            Description = "Test that trailing whitespace is treated the same way in SemVerFactory and OctopusVersionParser")]
         [TestCase(" 1.1.01-9999999999999999999999999 ",
             1,
             1,
@@ -398,7 +400,48 @@ namespace Octopus.Versioning.Tests.Octopus
             "9999999999999999999999999",
             "9999999999999999999999999",
             "",
-            "")]
+            "",
+            Description = "Test that leading whitespace is treated the same way in SemVerFactory and OctopusVersionParser")]
+        [TestCase(" 1 .1.01-9999999999999999999999999",
+            1,
+            1,
+            1,
+            0,
+            "9999999999999999999999999",
+            "9999999999999999999999999",
+            "",
+            "",
+            Description = "Test that whitespace around the major integer is treated the same way in SemVerFactory and OctopusVersionParser")]
+        [TestCase("1. 1 .01-9999999999999999999999999",
+            1,
+            1,
+            1,
+            0,
+            "9999999999999999999999999",
+            "9999999999999999999999999",
+            "",
+            "",
+            Description = "Test that whitespace around the minor integer is treated the same way in SemVerFactory and OctopusVersionParser")]
+        [TestCase("1.1. 01 -9999999999999999999999999",
+            1,
+            1,
+            1,
+            0,
+            "9999999999999999999999999",
+            "9999999999999999999999999",
+            "",
+            "",
+            Description = "Test that whitespace around the patch integer is treated the same way in SemVerFactory and OctopusVersionParser")]
+        [TestCase("1.1.01. 1 -9999999999999999999999999",
+            1,
+            1,
+            1,
+            1,
+            "9999999999999999999999999",
+            "9999999999999999999999999",
+            "",
+            "",
+            Description = "Test that whitespace around the release integer is treated the same way in SemVerFactory and OctopusVersionParser")]
         public void TestSemverVersions(string version,
             int major,
             int minor,
@@ -409,8 +452,8 @@ namespace Octopus.Versioning.Tests.Octopus
             string prereleaseCounter,
             string metadata)
         {
-            var parsed = OctopusVersionParser.Parse(version);
             var semverParsed = SemVerFactory.Parse(version);
+            var parsed = OctopusVersionParser.Parse(version);
 
             Assert.AreEqual(major, parsed.Major);
             Assert.AreEqual(major, semverParsed.Major);
@@ -991,6 +1034,8 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase(" 1.2.3-hi#there ")]
         [TestCase("1.2.3-hi&there")]
         [TestCase("1.2.3-hi there")]
+        [TestCase("1.2.3-hithere +meta", Description = "Ensure prerelease spaces are treated the same way in OctopusVersionParser and SemVerFactory")]
+        [TestCase("1.2.3-hithere+ meta", Description = "Ensure metadata spaces are treated the same way in OctopusVersionParser and SemVerFactory")]
         [TestCase(" ")]
         [TestCase("")]
         [TestCase(null)]

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -15,17 +15,28 @@ namespace Octopus.Versioning.Octopus
         const string PrereleaseCounter = "prereleasecounter";
         const string Meta = "buildmetadata";
 
+        /// <summary>
+        /// Note that we don't expect to see versions with spaces around the major, minor, patch, and release.
+        /// All the clients that can create an octopus version (the web ui, cli, library, and REST API) strip
+        /// spaces. However, the SemVerFactory.Parse() and SemVerFactory.TryParse() methods did accept
+        /// versions with these spaces. This led to cases where old Octopus instances had release versions with
+        /// spaces in them. To retain compatibility with the existing parsing logic, we tolerate whitespace
+        /// around version integers.
+        ///
+        /// See https://github.com/OctopusDeploy/Versioning/pull/20 and https://github.com/OctopusDeploy/Issues/issues/6826
+        /// for more details.
+        /// </summary>
         static readonly Regex VersionRegex = new Regex(@"^(?:" +
             // Versions can start with an optional V
             @$"(?<{Prefix}>v|V)?" +
             // Get the major version number
-            @$"(?<{Major}>\d+)" +
+            @$"\s*(?<{Major}>\d+)\s*" +
             // Get the minor version number, delimited by a period, comma, dash or underscore
-            @$"(?:\.(?<{Minor}>\d+))?" +
+            @$"(?:\.\s*(?<{Minor}>\d+)\s*)?" +
             // Get the patch version number, delimited by a period, comma, dash or underscore
-            @$"(?:\.(?<{Patch}>\d+))?" +
+            @$"(?:\.\s*(?<{Patch}>\d+)\s*)?" +
             // Get the revision version number, delimited by a period, comma, dash or underscore
-            @$"(?:\.(?<{Revision}>\d+))?)?" +
+            @$"(?:\.\s*(?<{Revision}>\d+)\s*)?)?" +
             // Everything after the last digit and before the plus is the prerelease
             @$"(?:[.\-_\\])?(?<{Prerelease}>(?<{PrereleasePrefix}>[A-Za-z0-9]*?)([.\-_\\](?<{PrereleaseCounter}>[A-Za-z0-9.\-_\\]*?)?)?)?" +
             // The metadata is everything after the plus

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -15,11 +15,6 @@ namespace Octopus.Versioning.Octopus
         const string PrereleaseCounter = "prereleasecounter";
         const string Meta = "buildmetadata";
 
-        /// <summary>
-        /// Versions can appear in URLs, and these characters are hard to work with in URLs, so we exclude them from any part of the version
-        /// </summary>
-        static readonly string[] IllegalChars = { "/", "%", "?", "#", "&" };
-
         static readonly Regex VersionRegex = new Regex(@"^(?:" +
             // Versions can start with an optional V
             @$"(?<{Prefix}>v|V)?" +

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -35,7 +35,7 @@ namespace Octopus.Versioning.Octopus
         {
             try
             {
-                if ((version?.Trim() ?? string.Empty) == string.Empty)
+                if (string.IsNullOrWhiteSpace(version))
                     throw new ArgumentException("The version can not be an empty string");
 
                 var result = VersionRegex.Match((version ?? string.Empty).Trim());

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -43,10 +43,7 @@ namespace Octopus.Versioning.Octopus
                 if ((version?.Trim() ?? string.Empty) == string.Empty)
                     throw new ArgumentException("The version can not be an empty string");
 
-                if (version?.Contains(" ") ?? false)
-                    throw new ArgumentException("The version can not contain spaces");
-
-                var result = VersionRegex.Match(version ?? string.Empty);
+                var result = VersionRegex.Match((version ?? string.Empty).Trim());
 
                 if (!result.Success)
                     throw new ArgumentException("The supplied version was not valid");


### PR DESCRIPTION
Octopus previously tolerated whitespace around version strings when parsing versions. For example, `SemVerFactory.TryCreateVersion("  1. 0. 0 -prerelease ")` would work.

This PR updates the new version parsing to also tolerate whitespace, and adds tests to confirm that the new parser workers the same as the old parser in these scenarios.