### PR TITLE
Add net4 back

### DIFF
--- a/source/Octopus.Versioning/Octopus.Versioning.csproj
+++ b/source/Octopus.Versioning/Octopus.Versioning.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net40;net5.0</TargetFrameworks>
     <AssemblyName>Octopus.Versioning</AssemblyName>
     <PackageId>Octopus.Versioning</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>

--- a/source/Octopus.Versioning/Octopus.Versioning.csproj
+++ b/source/Octopus.Versioning/Octopus.Versioning.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
     <AssemblyName>Octopus.Versioning</AssemblyName>
     <PackageId>Octopus.Versioning</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>


### PR DESCRIPTION
Calamari is still running `net40/net452` so we want to allow this repo to build for `net40` as well until Calamari is upgraded.

There are also more repos that depend on this package that are stuck on older versions of .net:
OpenSourceComponentsScanner
Octofront
OctopusCLI
Octostache
ServerExtensibility