### PR TITLE
Add GetHashCode to OctopusVersion and some equality methods on DockerTag

### DIFF
--- a/source/Octopus.Versioning.Tests/Docker/DockerVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Docker/DockerVersionCompareTests.cs
@@ -12,7 +12,13 @@ namespace Octopus.Versioning.Tests.Docker
         [TestCase("latest", "1.0.0", -1)]
         [TestCase("1.0.0", "latest", 1)]
         [TestCase("latest", "latest", 0)]
-        public void TestLatestVersions(string version1, string version2, int result)
+        [TestCase("1.2.3", "1.2.4", -1)]
+        [TestCase("1.2.4", "1.2.3", 1)]
+        [TestCase("1.2.3", "1.2.3", 0)]
+        [TestCase("1.2.3-pre-4", "1.2.3-pre-5", -1)]
+        [TestCase("1.2.3-pre-5", "1.2.3-pre-4", 1)]
+        [TestCase("1.2.3-pre-4", "1.2.3-pre-4", 0)]
+        public void CompareToShouldReturnCorrectValue(string version1, string version2, int result)
         {
             var ver1 = VersionFactory.CreateDockerTag(version1);
             var ver2 = VersionFactory.CreateDockerTag(version2);
@@ -24,16 +30,17 @@ namespace Octopus.Versioning.Tests.Docker
         [TestCase("latest", false)]
         [TestCase("1.0.0", false)]
         [TestCase("1.0.0-latest", true)]
-        public void TestPrerelease(string version1, bool result)
+        public void PrereleaseVersionsShouldBeLabelledCorrectly(string version1, bool result)
         {
             var ver1 = VersionFactory.CreateDockerTag(version1);
             Assert.AreEqual(result, ver1.IsPrerelease);
         }
+
         [Test]
         [TestCase("latest")]
         [TestCase("1.2.3")]
-        [TestCase("1.2.3-SNAPSHOT-4")]
-        public void TestMatchingVersionsAreGroupedCorrectly(string version)
+        [TestCase("1.2.3-pre-4")]
+        public void MatchingVersionsShouldBeGroupedCorrectly(string version)
         {
             var ver1 = VersionFactory.CreateDockerTag(version);
             var ver2 = VersionFactory.CreateDockerTag(version);
@@ -43,15 +50,42 @@ namespace Octopus.Versioning.Tests.Docker
         }
 
         [Test]
+        [TestCase("latest")]
+        [TestCase("1.2.3")]
+        [TestCase("1.2.3-pre-4")]
+        public void MatchingVersionsShouldHaveSameHashCodes(string version)
+        {
+            var ver1 = VersionFactory.CreateDockerTag(version);
+            var ver2 = VersionFactory.CreateDockerTag(version);
+
+            Assert.AreEqual(ver1.GetHashCode(), ver2.GetHashCode());
+        }
+
+        [Test]
         [TestCase("latest", "1.0.0")]
         [TestCase("1.2.3", "4.5.6")]
         [TestCase("1.2.3-pre-4", "1.2.3-pre-5")]
-        public void TestMismatchingVersionsHashCodesAreDifferent(string v1, string v2)
+        public void MismatchingVersionsShouldHaveDifferentHashCodes(string v1, string v2)
         {
             var ver1 = VersionFactory.CreateDockerTag(v1);
             var ver2 = VersionFactory.CreateDockerTag(v2);
 
             Assert.AreNotEqual(ver1.GetHashCode(), ver2.GetHashCode());
+        }
+
+        [Test]
+        [TestCase("latest", "latest", true)]
+        [TestCase("latest", "1.0.0", false)]
+        [TestCase("1.2.3", "1.2.3", true)]
+        [TestCase("1.2.3", "1.2.4", false)]
+        [TestCase("1.2.3-pre-4", "1.2.3-pre-4", true)]
+        [TestCase("1.2.3-pre-4", "1.2.3-pre-5", false)]
+        public void EqualsShouldReturnCorrectValue(string v1, string v2, bool expected)
+        {
+            var ver1 = VersionFactory.CreateDockerTag(v1);
+            var ver2 = VersionFactory.CreateDockerTag(v2);
+
+            Assert.AreEqual(expected, ver1.Equals(ver2));
         }
     }
 }

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
@@ -129,8 +129,8 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase("1.2.3-pre-4")]
         public void MatchingVersionsShouldBeGroupedCorrectly(string version)
         {
-            var ver1 = VersionFactory.CreateDockerTag(version);
-            var ver2 = VersionFactory.CreateDockerTag(version);
+            var ver1 = VersionFactory.CreateOctopusVersion(version);
+            var ver2 = VersionFactory.CreateOctopusVersion(version);
 
             var items = new List<IVersion> {ver1, ver2}.GroupBy(i => i).ToList();
             Assert.AreEqual(1, items.Count);
@@ -142,8 +142,8 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase("1.2.3-pre-4")]
         public void MatchingVersionsShouldHaveSameHashCodes(string version)
         {
-            var ver1 = VersionFactory.CreateDockerTag(version);
-            var ver2 = VersionFactory.CreateDockerTag(version);
+            var ver1 = VersionFactory.CreateOctopusVersion(version);
+            var ver2 = VersionFactory.CreateOctopusVersion(version);
 
             Assert.AreEqual(ver1.GetHashCode(), ver2.GetHashCode());
         }
@@ -154,8 +154,8 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase("1.2.3-pre-4", "1.2.3-pre-5")]
         public void MismatchingVersionsShouldHaveDifferentHashCodes(string v1, string v2)
         {
-            var ver1 = VersionFactory.CreateDockerTag(v1);
-            var ver2 = VersionFactory.CreateDockerTag(v2);
+            var ver1 = VersionFactory.CreateOctopusVersion(v1);
+            var ver2 = VersionFactory.CreateOctopusVersion(v2);
 
             Assert.AreNotEqual(ver1.GetHashCode(), ver2.GetHashCode());
         }

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionCompareTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using Octopus.Versioning.Octopus;
 using Octopus.Versioning.Semver;
@@ -119,6 +121,43 @@ namespace Octopus.Versioning.Tests.Octopus
                 Assert.GreaterOrEqual(result, 1);
             else
                 Assert.AreEqual(0, result);
+        }
+
+        [Test]
+        [TestCase("1.0.0")]
+        [TestCase("1.2.3")]
+        [TestCase("1.2.3-pre-4")]
+        public void MatchingVersionsShouldBeGroupedCorrectly(string version)
+        {
+            var ver1 = VersionFactory.CreateDockerTag(version);
+            var ver2 = VersionFactory.CreateDockerTag(version);
+
+            var items = new List<IVersion> {ver1, ver2}.GroupBy(i => i).ToList();
+            Assert.AreEqual(1, items.Count);
+        }
+
+        [Test]
+        [TestCase("1.0.0")]
+        [TestCase("1.2.3")]
+        [TestCase("1.2.3-pre-4")]
+        public void MatchingVersionsShouldHaveSameHashCodes(string version)
+        {
+            var ver1 = VersionFactory.CreateDockerTag(version);
+            var ver2 = VersionFactory.CreateDockerTag(version);
+
+            Assert.AreEqual(ver1.GetHashCode(), ver2.GetHashCode());
+        }
+
+        [Test]
+        [TestCase("1.0.1", "1.0.0")]
+        [TestCase("1.2.3", "4.5.6")]
+        [TestCase("1.2.3-pre-4", "1.2.3-pre-5")]
+        public void MismatchingVersionsShouldHaveDifferentHashCodes(string v1, string v2)
+        {
+            var ver1 = VersionFactory.CreateDockerTag(v1);
+            var ver2 = VersionFactory.CreateDockerTag(v2);
+
+            Assert.AreNotEqual(ver1.GetHashCode(), ver2.GetHashCode());
         }
     }
 }

--- a/source/Octopus.Versioning/Docker/DockerTag.cs
+++ b/source/Octopus.Versioning/Docker/DockerTag.cs
@@ -69,7 +69,6 @@ namespace Octopus.Versioning.Docker
 
         public override int GetHashCode()
         {
-
             return IsLatest ? Latest.GetHashCode() : base.GetHashCode();
         }
     }

--- a/source/Octopus.Versioning/Docker/DockerTag.cs
+++ b/source/Octopus.Versioning/Docker/DockerTag.cs
@@ -7,6 +7,7 @@ namespace Octopus.Versioning.Docker
     public class DockerTag : OctopusVersion
     {
         const string Latest = "latest";
+        bool IsLatest => string.Compare(OriginalString, Latest, StringComparison.Ordinal) == 0;
 
         public DockerTag(OctopusVersion version)
             : base(version.Prefix,
@@ -48,19 +49,28 @@ namespace Octopus.Versioning.Docker
 
         public override bool IsPrerelease => !string.IsNullOrEmpty(Release) && OriginalString != Latest;
 
-        public override int GetHashCode()
+        public override int CompareTo(object obj)
         {
-            if (OriginalString == Latest)
+            if (obj is DockerTag objDockerTag)
             {
-                return Latest.GetHashCode();
+                return IsLatest && objDockerTag.IsLatest ? 0 : base.CompareTo(obj);
             }
 
-            var hashCode = Major;
-            hashCode = (hashCode * 397) ^ Minor;
-            hashCode = (hashCode * 397) ^ Patch;
-            hashCode = (hashCode * 397) ^ Revision;
-            hashCode = (hashCode * 397) ^ Release.GetHashCode();
-            return hashCode;
+            return -1;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is DockerTag objDockerTag)
+                return CompareTo(objDockerTag) == 0;
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+
+            return IsLatest ? Latest.GetHashCode() : base.GetHashCode();
         }
     }
 }

--- a/source/Octopus.Versioning/Octopus/OctopusVersion.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersion.cs
@@ -89,6 +89,16 @@ namespace Octopus.Versioning.Octopus
             return false;
         }
 
+        public override int GetHashCode()
+        {
+            var hashCode = Major;
+            hashCode = (hashCode * 397) ^ Minor;
+            hashCode = (hashCode * 397) ^ Patch;
+            hashCode = (hashCode * 397) ^ Revision;
+            hashCode = (hashCode * 397) ^ Release.GetHashCode();
+            return hashCode;
+        }
+
         /// <summary>
         /// Compares sets of release labels.
         /// </summary>


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/Issues/issues/7379

`OctopusVersion` hash codes weren't returning the correct values. It was possible to have the same version with different hash codes. This PR fixes this and also adds Equals/CompareTo on DockerTag since it now has a `GetHashCode` method.

Also some test renaming + additions.