### PR TITLE
Fix NonPreReleaseTagsRegex by making it an exact match, not partial

### DIFF
--- a/octoversion.json
+++ b/octoversion.json
@@ -1,3 +1,3 @@
 {
-  "NonPreReleaseTagsRegex": "refs/heads/(main|master|release/.*)"
+  "NonPreReleaseTagsRegex": "^refs/heads/(main|master|release/.*)$"
 }


### PR DESCRIPTION
Without this fix, `refs/heads/main-nightly` for example is equivalent to `refs/heads/main` and will get published to NuGet when it shouldn't.