### PR TITLE
Use .NET 8 SDK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
 
       # Adjustment is done prior to Nuke build as OCTOVERSION information is included in the result package.
       - name: Append OCTOVERSION_CurrentBranch with -nightly (for scheduled)

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -24,7 +24,7 @@ class Build : NukeBuild
     [Parameter("Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable " + CiBranchNameEnvVariable + ".", Name = CiBranchNameEnvVariable)]
     readonly string OctoVersionBranch = null!; // assigned by Nuke via reflection
 
-    [Parameter] readonly int? OctoVersionFullSemVer;
+    [Parameter] readonly string? OctoVersionFullSemVer;
     [Parameter] readonly int? OctoVersionMajor;
     [Parameter] readonly int? OctoVersionMinor;
     [Parameter] readonly int? OctoVersionPatch;

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -21,8 +21,10 @@ class Build : NukeBuild
 
     [Parameter] readonly bool? OctoVersionAutoDetectBranch = NukeBuild.IsLocalBuild;
 
+#pragma warning disable CS0414 // Field assigned but never used
     [Parameter("Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable " + CiBranchNameEnvVariable + ".", Name = CiBranchNameEnvVariable)]
     readonly string OctoVersionBranch = null!; // assigned by Nuke via reflection
+#pragma warning restore CS0414
 
     [Parameter] readonly string? OctoVersionFullSemVer;
     [Parameter] readonly int? OctoVersionMajor;

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using Nuke.Common;
-using Nuke.Common.CI;
 using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
@@ -10,8 +8,8 @@ using Nuke.Common.Utilities.Collections;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 using Nuke.Common.Tools.OctoVersion;
+using Serilog;
 
-[CheckBuildProjectConfigurations]
 [UnsetVisualStudioEnvironmentVariables]
 class Build : NukeBuild
 {
@@ -19,12 +17,12 @@ class Build : NukeBuild
 
     readonly Configuration Configuration = Configuration.Release;
 
-    [Solution] readonly Solution Solution;
+    [Solution] readonly Solution Solution = null!; // assigned by Nuke via reflection
 
     [Parameter] readonly bool? OctoVersionAutoDetectBranch = NukeBuild.IsLocalBuild;
 
     [Parameter("Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable " + CiBranchNameEnvVariable + ".", Name = CiBranchNameEnvVariable)]
-    readonly string OctoVersionBranch;
+    readonly string OctoVersionBranch = null!; // assigned by Nuke via reflection
 
     [Parameter] readonly int? OctoVersionFullSemVer;
     [Parameter] readonly int? OctoVersionMajor;
@@ -33,15 +31,14 @@ class Build : NukeBuild
 
     [Required]
     [OctoVersion(
-        AutoDetectBranchParameter = nameof(OctoVersionAutoDetectBranch),
-        BranchParameter = nameof(OctoVersionBranch),
-        FullSemVerParameter = nameof(OctoVersionFullSemVer),
-        MajorParameter = nameof(OctoVersionMajor),
-        MinorParameter = nameof(OctoVersionMinor),
-        PatchParameter = nameof(OctoVersionPatch),
-        Framework = "net6.0")]
-
-    readonly OctoVersionInfo OctoVersionInfo;
+        AutoDetectBranchMember = nameof(OctoVersionAutoDetectBranch),
+        BranchMember = nameof(OctoVersionBranch),
+        FullSemVerMember = nameof(OctoVersionFullSemVer),
+        MajorMember = nameof(OctoVersionMajor),
+        MinorMember = nameof(OctoVersionMinor),
+        PatchMember = nameof(OctoVersionPatch),
+        Framework = "net8.0")]
+    readonly OctoVersionInfo OctoVersionInfo = null!; // assigned by Nuke via reflection
 
     static AbsolutePath SourceDirectory => RootDirectory / "source";
     static AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
@@ -52,9 +49,9 @@ class Build : NukeBuild
         .Before(Restore)
         .Executes(() =>
         {
-            SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(DeleteDirectory);
-            EnsureCleanDirectory(ArtifactsDirectory);
-            EnsureCleanDirectory(PublishDirectory);
+            SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(x => x.DeleteDirectory());
+            ArtifactsDirectory.CreateOrCleanDirectory();
+            PublishDirectory.CreateOrCleanDirectory();
         });
 
     Target Restore => _ => _
@@ -70,7 +67,7 @@ class Build : NukeBuild
         .DependsOn(Restore)
         .Executes(() =>
         {
-            Logger.Info("Building Octopus Versioning v{0}", OctoVersionInfo.FullSemVer);
+            Log.Information("Building Octopus Versioning v{0}", OctoVersionInfo.FullSemVer);
 
             DotNetBuild(_ => _
                 .SetProjectFile(Solution)
@@ -96,7 +93,7 @@ class Build : NukeBuild
         .Produces(ArtifactsDirectory / "*.nupkg")
         .Executes(() =>
         {
-            Logger.Info("Packing Octopus Versioning v{0}", OctoVersionInfo.FullSemVer);
+            Log.Information("Packing Octopus Versioning v{0}", OctoVersionInfo.FullSemVer);
 
             // This is done to pass the data to github actions
             Console.Out.WriteLine($"::set-output name=semver::{OctoVersionInfo.FullSemVer}");
@@ -118,7 +115,7 @@ class Build : NukeBuild
         .TriggeredBy(Pack)
         .Executes(() =>
         {
-            EnsureExistingDirectory(LocalPackagesDir);
+            LocalPackagesDir.CreateDirectory();
             ArtifactsDirectory.GlobFiles("*.nupkg")
                 .ForEach(package =>
                 {

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,20 +2,23 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <!-- NET8: Remove this when Nuke releases a new version which sets it for us -->
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.4.0-mattr-octoversio0017" />
+    <PackageReference Include="Nuke.Common" Version="7.0.6" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.49]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.293]" />
   </ItemGroup>
 
 </Project>

--- a/source/Octopus.Versioning.Tests/Octopus.Versioning.Tests.csproj
+++ b/source/Octopus.Versioning.Tests/Octopus.Versioning.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Octopus.Versioning.Tests</AssemblyName>
     <PackageId>Octopus.Versioning.Tests</PackageId>
     <PackageIconUrl>http://i.octopusdeploy.com/resources/Avatar3_360.png</PackageIconUrl>


### PR DESCRIPTION
[sc-65325]

Updates this project to use the .NET 8 SDK for compilation and testing.
The library itself is still published under `netstandard2.0`.