### PR TITLE
Fix github script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            github.git.createRef({
+            github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "refs/tags/${{ steps.build.outputs.octoversion_fullsemver }}",


### PR DESCRIPTION
In a previous PR I updated the GHA workflow `actions/github-script` from `@v3` to `@v7`.

In [v5, github issued a breaking change](https://github.com/actions/github-script#v5), so we need to use `github.rest.git.createRef` rather than `github.git.createRef`

This PR applies that fix