### PR TITLE
Updated OctopusVersionParser regex to ensure delimiters between version numbers

### DIFF
--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -1081,7 +1081,25 @@ namespace Octopus.Versioning.Tests.Octopus
             0,
             0,
             "123ABC.123")]
-        public void TestVersionNumbersAreDelimited(string inputVersion, int major, int minor, int patch, int revision, string release)
+        [TestCase("1.0_prerelease",
+            1,
+            0,
+            0,
+            0,
+            "prerelease")]
+        [TestCase("V1.0",
+            1,
+            0,
+            0,
+            0,
+            "")]
+        [TestCase("v1.0",
+            1,
+            0,
+            0,
+            0,
+            "")]
+        public void TestVersionNumberVariations(string inputVersion, int major, int minor, int patch, int revision, string release)
         {
             var parsedVersion = OctopusVersionParser.Parse(inputVersion);
             Assert.AreEqual(major, parsedVersion.Major);

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionTests.cs
@@ -683,32 +683,6 @@ namespace Octopus.Versioning.Tests.Octopus
             "0",
             "alpha",
             "")]
-        [TestCase("1_0_alpha",
-            1,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            "",
-            "0_alpha",
-            "0",
-            "alpha",
-            "")]
-        [TestCase("1_0alpha",
-            1,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            "",
-            "0alpha",
-            "0alpha",
-            "",
-            "")]
         [TestCase("1.0a1-SNAPSHOT",
             1,
             0,
@@ -718,8 +692,8 @@ namespace Octopus.Versioning.Tests.Octopus
             0,
             0,
             "",
-            "a1-SNAPSHOT",
-            "a1",
+            "0a1-SNAPSHOT",
+            "0a1",
             "SNAPSHOT",
             "")]
         [TestCase("1-2.3-SNAPSHOT",
@@ -1076,6 +1050,47 @@ namespace Octopus.Versioning.Tests.Octopus
             Assert.AreEqual(octoVersion.OriginalString, semanticVersion.OriginalString);
         }
 
+        [Test]
+        [TestCase("123",
+            123,
+            0,
+            0,
+            0,
+            "")]
+        [TestCase("123ABC",
+            0,
+            0,
+            0,
+            0,
+            "123ABC")]
+        [TestCase("123ABC-CBC",
+            0,
+            0,
+            0,
+            0,
+            "123ABC-CBC")]
+        [TestCase("123.123.123.123",
+            123,
+            123,
+            123,
+            123,
+            "")]
+        [TestCase("123.123ABC.123",
+            123,
+            0,
+            0,
+            0,
+            "123ABC.123")]
+        public void TestVersionNumbersAreDelimited(string inputVersion, int major, int minor, int patch, int revision, string release)
+        {
+            var parsedVersion = OctopusVersionParser.Parse(inputVersion);
+            Assert.AreEqual(major, parsedVersion.Major);
+            Assert.AreEqual(minor, parsedVersion.Minor);
+            Assert.AreEqual(patch, parsedVersion.Patch);
+            Assert.AreEqual(revision, parsedVersion.Revision);
+            Assert.AreEqual(release, parsedVersion.Release);
+        }
+
         public static string RandomString(int length)
         {
             const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-.\\+";
@@ -1083,5 +1098,6 @@ namespace Octopus.Versioning.Tests.Octopus
                 .Select(s => s[Random.Next(s.Length)])
                 .ToArray());
         }
+        
     }
 }

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -30,13 +30,13 @@ namespace Octopus.Versioning.Octopus
             // Versions can start with an optional V
             @$"\s*(?<{Prefix}>v|V)?" +
             // Get the major version number
-            @$"\s*(?<{Major}>\d+)\s*" +
+            @$"\s*(?<{Major}>\d+\b)\s*" +
             // Get the minor version number, delimited by a period, comma, dash or underscore
-            @$"(?:\.\s*(?<{Minor}>\d+)\s*)?" +
+            @$"(?:\.\s*(?<{Minor}>\d+\b)\s*)?" +
             // Get the patch version number, delimited by a period, comma, dash or underscore
-            @$"(?:\.\s*(?<{Patch}>\d+)\s*)?" +
+            @$"(?:\.\s*(?<{Patch}>\d+\b)\s*)?" +
             // Get the revision version number, delimited by a period, comma, dash or underscore
-            @$"(?:\.\s*(?<{Revision}>\d+)\s*)?)?" +
+            @$"(?:\.\s*(?<{Revision}>\d+\b)\s*)?)?" +
             // Everything after the last digit and before the plus is the prerelease
             @$"(?:[.\-_\\])?(?<{Prerelease}>(?<{PrereleasePrefix}>[A-Za-z0-9]*?)([.\-_\\](?<{PrereleaseCounter}>[A-Za-z0-9.\-_\\]*?)?)?)?" +
             // The metadata is everything after the plus

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -31,11 +31,11 @@ namespace Octopus.Versioning.Octopus
             @$"\s*(?<{Prefix}>v|V)?" +
             // Get the major version number
             @$"\s*(?<{Major}>\d+\b)\s*" +
-            // Get the minor version number, delimited by a period, comma, dash or underscore
+            // Get the minor version number, delimited by a period
             @$"(?:\.\s*(?<{Minor}>\d+\b)\s*)?" +
-            // Get the patch version number, delimited by a period, comma, dash or underscore
+            // Get the patch version number, delimited by a period
             @$"(?:\.\s*(?<{Patch}>\d+\b)\s*)?" +
-            // Get the revision version number, delimited by a period, comma, dash or underscore
+            // Get the revision version number, delimited by a period
             @$"(?:\.\s*(?<{Revision}>\d+\b)\s*)?)?" +
             // Everything after the last digit and before the plus is the prerelease
             @$"(?:[.\-_\\])?(?<{Prerelease}>(?<{PrereleasePrefix}>[A-Za-z0-9]*?)([.\-_\\](?<{PrereleaseCounter}>[A-Za-z0-9.\-_\\]*?)?)?)?" +

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -30,13 +30,13 @@ namespace Octopus.Versioning.Octopus
             // Versions can start with an optional V
             @$"\s*(?<{Prefix}>v|V)?" +
             // Get the major version number
-            @$"\s*(?<{Major}>\d+\b)\s*" +
+            @$"\s*(?<{Major}>\d+(?=\b|_))\s*" +
             // Get the minor version number, delimited by a period
-            @$"(?:\.\s*(?<{Minor}>\d+\b)\s*)?" +
+            @$"(?:\.\s*(?<{Minor}>\d+(?=\b|_))\s*)?" +
             // Get the patch version number, delimited by a period
-            @$"(?:\.\s*(?<{Patch}>\d+\b)\s*)?" +
+            @$"(?:\.\s*(?<{Patch}>\d+(?=\b|_))\s*)?" +
             // Get the revision version number, delimited by a period
-            @$"(?:\.\s*(?<{Revision}>\d+\b)\s*)?)?" +
+            @$"(?:\.\s*(?<{Revision}>\d+(?=\b|_))\s*)?)?" +
             // Everything after the last digit and before the plus is the prerelease
             @$"(?:[.\-_\\])?(?<{Prerelease}>(?<{PrereleasePrefix}>[A-Za-z0-9]*?)([.\-_\\](?<{PrereleaseCounter}>[A-Za-z0-9.\-_\\]*?)?)?)?" +
             // The metadata is everything after the plus


### PR DESCRIPTION
# Background 
[SC-67249]

`OctopusVersionParser` incorrectly parsed some version strings. Example: 
```
Input: 123ABC
Result: 
    Major: 123
    Minor: 0
    Patch: 0
    Revision: 0
    Release: ABC
```

While the above example wouldn't cause issues there is cases where if an input version string started with a number that was larger than `int32.MaxValue` it would cause an overflow exception to be thrown.

# Solution
The regex has been updated to requires a word boundary directly after the version numbers in the version string to ensure that version numbers are correctly delimited

## Examples

### Old Regex:
![Screenshot 2024-01-04 at 3 41 37 pm](https://github.com/OctopusDeploy/Versioning/assets/3272176/7404818a-4ad2-48d4-adb5-bc83453ebf7b)


### New Regex:
![Screenshot 2024-01-04 at 3 41 58 pm](https://github.com/OctopusDeploy/Versioning/assets/3272176/fbfe1b07-74e7-44c2-a306-f44dee341dcd)


# Warning
This is a breaking change, some versions that previously parsed will no longer parse, this is limited to versions that didn't have a separator character between the first version number and the rest of the version string e.g. `1_0Alpha` will now result in `0.0.0-1_0Alpha` rather than `1.0.0-0Alpha`. The effect of this is that packages that have incorrect version strings will no longer sort correctly 