### PR TITLE
Added tests that verify single digits are valid semver strings

### DIFF
--- a/source/Octopus.Versioning.Tests/VersionTests.cs
+++ b/source/Octopus.Versioning.Tests/VersionTests.cs
@@ -85,6 +85,23 @@ namespace Octopus.Versioning.Tests.Versions
         }
 
         [Test]
+        public void TestSingleDigit()
+        {
+            Assert.AreEqual(
+                VersionFactory.CreateSemanticVersion("0001"),
+                VersionFactory.CreateSemanticVersion("1.0.0.0"));
+            Assert.AreEqual(
+                VersionFactory.CreateSemanticVersion("0001"),
+                VersionFactory.CreateSemanticVersion("1.0"));
+            Assert.AreEqual(
+                VersionFactory.CreateSemanticVersion("0001"),
+                VersionFactory.CreateSemanticVersion("1"));
+            Assert.AreEqual(
+                VersionFactory.CreateSemanticVersion("1"),
+                VersionFactory.CreateSemanticVersion("1.0.0.0"));
+        }
+
+        [Test]
         public void TestInvalidVersion()
         {
             Assert.Null(VersionFactory.TryCreateVersion("1.0.*", VersionFormat.Semver));


### PR DESCRIPTION
We have a customer that uses the Artifactory generic feed, but who is using single digit build numbers as versions (i.e. `0001`, `0002` etc).

These versions numbers are valid semver versions as defined by this library, but there are no tests that explicitly verify this. This PR adds a few simple tests to make it clear that a string like `0001` is a valid semver version.