### PR TITLE
OIDC login for Octopus Deploy when publishing builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,43 +16,54 @@ on:
   schedule:
     # Daily 5am australian/brisbane time
     - cron: '0 19 * * *'
-
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
-# Pass branch and patch number to Nuke OctoVersion
-# (for pull_request events we override the /refs/pull/xx/merge branch to the PR's head branch)
+    # Allows you to run this workflow manually from the Actions tab
+ 
 env:
   OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref }}
-  OCTOVERSION_Patch: ${{ github.run_number }}
-  AssentNonInteractive: true
+  OCTOPUS_SPACE: Integrations
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    name: "Build, Test and Publish" # Branch protections required check matches against this
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required to obtain the ID token from GitHub Actions
+      contents: write # Read Required to check out code, Write to create Git Tags
+      checks: write # Required for test-reporter
     steps:
-      - uses: actions/checkout@v4
+      # Must clone the entire history for OctoVersion to work
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # all
+          fetch-depth: 0 
 
-      - name: Setup .NET
+      - name: Setup .NET 8
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
 
-      # Adjustment is done prior to Nuke build as OCTOVERSION information is included in the result package.
-      - name: Append OCTOVERSION_CurrentBranch with -nightly (for scheduled)
+      - name: Append OCTOVERSION_CurrentBranch with -nightly-<timestamp> (for scheduled)
         if: github.event_name == 'schedule'
-        run: echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly" >> $GITHUB_ENV
+        run: |
+          echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
-      - name: Nuke Build 🏗
+      - name: Nuke Build
         id: build
-        shell: bash
         run: ./build.sh
-        
-      - name: Tag release (when not pre-release) 🏷️
+
+      - name: Publish Test Results
+        uses: dorny/test-reporter@v1
+        if: success() || failure()    # run this step even if previous step failed
+        with:
+          name: Test Results
+          path: ./source/Octopus.Versioning.Tests/TestResults/*.trx
+          reporter: dotnet-trx
+          fail-on-error: true
+
+      - name: Git Tag (when not pre-release) 🏷️
         id: github-tag
-        if: ${{ github.event_name != 'schedule' && !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
+        if: ${{ !contains( steps.build.outputs.octoversion_fullsemver, '-' ) }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -64,21 +75,34 @@ jobs:
               sha: context.sha
             })
 
-      - name: Push to Octopus 🐙
-        uses: OctopusDeploy/push-package-action@v3
+      - name: Login to Octopus Deploy 🐙
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
+        uses: OctopusDeploy/login@v1
+        with: 
+          server: https://deploy.octopus.app
+          service_account_id: 235214cc-3dec-4814-bfa0-3b82af8dc95e
+
+      - name: Push build information to Octopus Deploy 🐙
+        uses: OctopusDeploy/push-build-information-action@v3
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         with:
-          server: ${{ secrets.DEPLOY_URL }}
-          space: Integrations
-          api_key: ${{ secrets.DEPLOY_API_KEY }}
+          packages: |
+            Octopus.TinyTypes
+            Octopus.TinyTypes.Json
+          version: ${{ steps.build.outputs.octoversion_fullsemver }}
+
+      - name: Push Packages to Octopus Deploy 🐙
+        uses: OctopusDeploy/push-package-action@v3
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
+        with:
           packages: |
             ./artifacts/Octopus.Versioning.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
 
-      - name: Create Release in Octopus 🐙
+      - name: Create Octopus Release 🐙
         uses: OctopusDeploy/create-release-action@v3
+        if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         with:
-          server: ${{ secrets.DEPLOY_URL }}
-          space: Integrations
-          api_key: ${{ secrets.DEPLOY_API_KEY }}
-          project: "Versioning"
+          project: Versioning
+          release_number: ${{ steps.build.outputs.octoversion_fullsemver }}
           packages: |
             Octopus.Versioning:${{ steps.build.outputs.octoversion_fullsemver }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,14 +32,13 @@ jobs:
       contents: write # Read Required to check out code, Write to create Git Tags
       checks: write # Required for test-reporter
     steps:
-      # Must clone the entire history for OctoVersion to work
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 
 
-      - name: Setup .NET 8
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 
@@ -80,15 +79,14 @@ jobs:
         uses: OctopusDeploy/login@v1
         with: 
           server: https://deploy.octopus.app
-          service_account_id: 235214cc-3dec-4814-bfa0-3b82af8dc95e
+          service_account_id: c6e32234-4fff-4813-b6be-7b1047b717f0
 
       - name: Push build information to Octopus Deploy 🐙
         uses: OctopusDeploy/push-build-information-action@v3
         if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         with:
           packages: |
-            Octopus.TinyTypes
-            Octopus.TinyTypes.Json
+            ./artifacts/Octopus.Versioning.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
           version: ${{ steps.build.outputs.octoversion_fullsemver }}
 
       - name: Push Packages to Octopus Deploy 🐙

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
         if: (! contains(github.ref, '/merge')) && (! contains(github.ref, '/dependabot/')) && (! contains(github.ref, 'prettybot/'))
         with:
           packages: |
-            ./artifacts/Octopus.Versioning.${{ steps.build.outputs.octoversion_fullsemver }}.nupkg
+            Octopus.Versioning.${{ steps.build.outputs.octoversion_fullsemver }}
           version: ${{ steps.build.outputs.octoversion_fullsemver }}
 
       - name: Push Packages to Octopus Deploy 🐙

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
   "$ref": "#/definitions/build",
+  "title": "Build Schema",
   "definitions": {
     "build": {
       "type": "object",
@@ -21,6 +21,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",
@@ -38,14 +39,15 @@
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
         },
+        "OCTOVERSION_CurrentBranch": {
+          "type": "string",
+          "description": "Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable OCTOVERSION_CurrentBranch"
+        },
         "OctoVersionAutoDetectBranch": {
           "type": "boolean"
         },
-        "OctoVersionBranch": {
-          "type": "string"
-        },
         "OctoVersionFullSemVer": {
-          "type": "integer"
+          "type": "string"
         },
         "OctoVersionMajor": {
           "type": "integer"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -87,6 +87,8 @@ class Build : NukeBuild
                 .SetConfiguration(Configuration)
                 .SetNoBuild(true)
                 .EnableNoRestore()
+                .SetLoggers("trx")
+                .SetVerbosity(DotNetVerbosity.Normal)
                 .SetFilter(@"FullyQualifiedName\!~Integration.Tests"));
         });
 


### PR DESCRIPTION
# Background

The nightly builds have been [failing recently](https://github.com/OctopusDeploy/Versioning/actions/runs/12856333309).

The "Push to Octopus" step is failing with 

```
Error: The API key you provided was not valid. Please double-check your API key and try again. For instructions on finding your API key, please visit: https://oc.to/ApiKey
```

This is an obvious signal that the API key has expired.

We don't need an API key. We can use OIDC login and prevent this expiry problem from ever happening again

# Results

Updates the action to use OIDC login, following the template set by [OctoDiff](https://github.com/OctopusDeploy/Octodiff/blob/master/.github/workflows/main.yml) which is used by most projects owned by the backend foundations team.

# Reducing Risk

The process doesn't login to octopus or publish for PR validation builds.

I've manually triggered a branch build here so we can observe the OIDC login and publishing works correctly:
https://github.com/OctopusDeploy/Versioning/actions/runs/12857898897/job/35846310070

The created release in Octopus for that run is [5.1.881-orion-oidc-and-tests](https://deploy.octopus.app/app#/Spaces-62/projects/versioning/deployments/releases/5.1.881-orion-oidc-and-tests).