### PR TITLE
🧹 Added dependabot and implemented hash pinning for third party actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         run: ./build.sh
 
       - name: Publish Test Results
-        uses: dorny/test-reporter@v1
+        uses: dorny/test-reporter@6e6a65b7a0bd2c9197df7d0ae36ac5cee784230c # v2.0.0
         if: success() || failure()    # run this step even if previous step failed
         with:
           name: Test Results


### PR DESCRIPTION
Added dependabot to check github actions and pinned third party actions, have left the default github and the internal actions.

Dependabot will now run weekly for this repo and check the github actions for updates

Also updated dorny/test-reporter to v2, and pinned release