### PR TITLE
Added deterministic ordering on metadata

### DIFF
--- a/source/Octopus.Versioning.Tests/Octopus.Versioning.Tests.csproj
+++ b/source/Octopus.Versioning.Tests/Octopus.Versioning.Tests.csproj
@@ -9,8 +9,6 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Copyright>Copyright © Octopus Deploy 2017</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- nuget packages with security warnings should not break the build -->
-    <WarningsNotAsErrors>CS0618,NU1901,NU1902,NU1903</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octopus.Versioning\Octopus.Versioning.csproj" />

--- a/source/Octopus.Versioning.Tests/Octopus.Versioning.Tests.csproj
+++ b/source/Octopus.Versioning.Tests/Octopus.Versioning.Tests.csproj
@@ -9,6 +9,8 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <Copyright>Copyright © Octopus Deploy 2017</Copyright>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <!-- nuget packages with security warnings should not break the build -->
+    <WarningsNotAsErrors>CS0618,NU1901,NU1902,NU1903</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Octopus.Versioning\Octopus.Versioning.csproj" />

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
@@ -223,7 +223,7 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
-        public void GetLatestMaskedVersionShouldNotBeOrderDependent()
+        public void GetLatestMaskedVersionShouldUseOrderPassedInToTieBreak()
         {
             var mask = OctopusVersionMaskParser.Parse("0.0.7+branchA.c.c.i");
             var versionParser = new OctopusVersionParser();
@@ -231,7 +231,7 @@ namespace Octopus.Versioning.Tests.Octopus
             var versions = new[]
                 {
                     "0.0.7+branchA.1",
-                    "0.0.7+branchA",
+                    "0.0.7+branchA.2", 
                     "0.0.6+branchA",
                     "0.0.5-beta.2",
                     "0.0.5-beta.1",
@@ -242,13 +242,17 @@ namespace Octopus.Versioning.Tests.Octopus
                 }.Select(v => (IVersion)versionParser.Parse(v))
                 .ToList();
 
-            // This is the correct answer that we are looking for
-            Assert.AreEqual("0.0.7+branchA.1", mask.GetLatestMaskedVersion(versions)!.ToString());
+            // GetLatestMaskedVersion, ignores metata when comparing versions, we verify tiebreak behaviour on matching versions.
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("0.0.7+branchA.1", mask.GetLatestMaskedVersion(versions)!.ToString(), "Because version with metadata of '+branchA.1' is first in the list passed in");
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Now the real test; it should still return the same result even if the versions are not in the correct order
             var reversedVersions = versions.ToList();
             reversedVersions.Reverse();
-            Assert.AreEqual("0.0.7+branchA.1", mask.GetLatestMaskedVersion(reversedVersions)!.ToString());
+#pragma warning disable CS0618 // Type or member is obsolete
+            Assert.AreEqual("0.0.7+branchA.2", mask.GetLatestMaskedVersion(reversedVersions)!.ToString(),"Because we reversed the order of the list, so `+branchA.2` is now first in the list.");
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
@@ -202,6 +202,7 @@ namespace Octopus.Versioning.Tests.Octopus
         [TestCase("1.2.i", "1.2.3", "1.2.3")]
         [TestCase("1.i.i", "1.2.3", "1.2.3")]
         [TestCase("1.i.i", "2.0.0", null)]
+        [Obsolete]
         public void GetLatestVersionMask(string version, string latestVersion, string expected)
         {
             var latestVersions = new List<IVersion>
@@ -223,6 +224,7 @@ namespace Octopus.Versioning.Tests.Octopus
         }
 
         [Test]
+        [Obsolete]
         public void GetLatestMaskedVersionShouldUseOrderPassedInToTieBreak()
         {
             var mask = OctopusVersionMaskParser.Parse("0.0.7+branchA.c.c.i");
@@ -243,16 +245,12 @@ namespace Octopus.Versioning.Tests.Octopus
                 .ToList();
 
             // GetLatestMaskedVersion, ignores metata when comparing versions, we verify tiebreak behaviour on matching versions.
-#pragma warning disable CS0618 // Type or member is obsolete
             Assert.AreEqual("0.0.7+branchA.1", mask.GetLatestMaskedVersion(versions)!.ToString(), "Because version with metadata of '+branchA.1' is first in the list passed in");
-#pragma warning restore CS0618 // Type or member is obsolete
 
             // Now the real test; it should still return the same result even if the versions are not in the correct order
             var reversedVersions = versions.ToList();
             reversedVersions.Reverse();
-#pragma warning disable CS0618 // Type or member is obsolete
             Assert.AreEqual("0.0.7+branchA.2", mask.GetLatestMaskedVersion(reversedVersions)!.ToString(),"Because we reversed the order of the list, so `+branchA.2` is now first in the list.");
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Test]

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
@@ -233,7 +233,7 @@ namespace Octopus.Versioning.Tests.Octopus
             var versions = new[]
                 {
                     "0.0.7+branchA.1",
-                    "0.0.7+branchA.2", 
+                    "0.0.7+branchA.2",
                     "0.0.6+branchA",
                     "0.0.5-beta.2",
                     "0.0.5-beta.1",
@@ -250,7 +250,7 @@ namespace Octopus.Versioning.Tests.Octopus
             // Now the real test; it should still return the same result even if the versions are not in the correct order
             var reversedVersions = versions.ToList();
             reversedVersions.Reverse();
-            Assert.AreEqual("0.0.7+branchA.2", mask.GetLatestMaskedVersion(reversedVersions)!.ToString(),"Because we reversed the order of the list, so `+branchA.2` is now first in the list.");
+            Assert.AreEqual("0.0.7+branchA.2", mask.GetLatestMaskedVersion(reversedVersions)!.ToString(), "Because we reversed the order of the list, so `+branchA.2` is now first in the list.");
         }
 
         [Test]
@@ -262,7 +262,7 @@ namespace Octopus.Versioning.Tests.Octopus
             var versions = new[]
                 {
                     "0.0.7+branchA.1",
-                    "0.0.7+branchA.2", 
+                    "0.0.7+branchA.2",
                     "0.0.6+branchA",
                     "0.0.5-beta.2",
                     "0.0.5-beta.1",
@@ -276,11 +276,12 @@ namespace Octopus.Versioning.Tests.Octopus
             var result = mask.GetLatestMaskedVersions(versions);
 
             // Should return both 0.0.7 versions since they have the same precedence (metadata is ignored in comparison)
-            CollectionAssert.AreEquivalent(new[] 
-            { 
-                "0.0.7+branchA.1", 
-                "0.0.7+branchA.2" 
-            }, result.Select(r => r.ToString()));
+            CollectionAssert.AreEquivalent(new[]
+                {
+                    "0.0.7+branchA.1",
+                    "0.0.7+branchA.2"
+                },
+                result.Select(r => r.ToString()));
         }
 
         [Test]
@@ -344,18 +345,17 @@ namespace Octopus.Versioning.Tests.Octopus
             var result = mask.GetLatestMaskedVersions(versions);
 
             // Should return all 1.2.3 versions since they have the same precedence (metadata is ignored in comparison)
-            CollectionAssert.AreEquivalent(new[] 
-            { 
-                "1.2.3+20231201.1430",
-                "1.2.3+build.456",
-                "1.2.3+commit.abc123f",
-                "1.2.3+feature-branch.45",
-                "1.2.3+build.789.20231201"
-            }, result.Select(r => r.ToString()));
-            
-            // Verify that versions with different core numbers are not included
-            Assert.False(result.Any(v => v.ToString() == "1.2.2+anything"), "Should not include lower version");
-            Assert.False(result.Any(v => v.ToString() == "1.2.4+something"), "Should not include higher version");
+            CollectionAssert.AreEquivalent(new[]
+                {
+                    "1.2.3+20231201.1430",
+                    "1.2.3+build.456",
+                    "1.2.3+commit.abc123f",
+                    "1.2.3+feature-branch.45",
+                    "1.2.3+build.789.20231201"
+                },
+                result.Select(r => r.ToString()),
+                "Because these match the mask of 1.2.3, it should not include lower version or higher version"
+            );
         }
     }
 }

--- a/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
+++ b/source/Octopus.Versioning.Tests/Octopus/OctopusVersionMaskParserTests.cs
@@ -276,9 +276,11 @@ namespace Octopus.Versioning.Tests.Octopus
             var result = mask.GetLatestMaskedVersions(versions);
 
             // Should return both 0.0.7 versions since they have the same precedence (metadata is ignored in comparison)
-            Assert.AreEqual(2, result.Count, "Should return both versions with highest precedence");
-            Assert.True(result.Any(v => v.ToString() == "0.0.7+branchA.1"), "Should include 0.0.7+branchA.1");
-            Assert.True(result.Any(v => v.ToString() == "0.0.7+branchA.2"), "Should include 0.0.7+branchA.2");
+            CollectionAssert.AreEquivalent(new[] 
+            { 
+                "0.0.7+branchA.1", 
+                "0.0.7+branchA.2" 
+            }, result.Select(r => r.ToString()));
         }
 
         [Test]
@@ -342,12 +344,14 @@ namespace Octopus.Versioning.Tests.Octopus
             var result = mask.GetLatestMaskedVersions(versions);
 
             // Should return all 1.2.3 versions since they have the same precedence (metadata is ignored in comparison)
-            Assert.AreEqual(5, result.Count, "Should return all versions with matching core version 1.2.3");
-            Assert.True(result.Any(v => v.ToString() == "1.2.3+20231201.1430"), "Should include datetime metadata version");
-            Assert.True(result.Any(v => v.ToString() == "1.2.3+build.456"), "Should include build number metadata version");
-            Assert.True(result.Any(v => v.ToString() == "1.2.3+commit.abc123f"), "Should include git commit metadata version");
-            Assert.True(result.Any(v => v.ToString() == "1.2.3+feature-branch.45"), "Should include branch metadata version");
-            Assert.True(result.Any(v => v.ToString() == "1.2.3+build.789.20231201"), "Should include combined metadata version");
+            CollectionAssert.AreEquivalent(new[] 
+            { 
+                "1.2.3+20231201.1430",
+                "1.2.3+build.456",
+                "1.2.3+commit.abc123f",
+                "1.2.3+feature-branch.45",
+                "1.2.3+build.789.20231201"
+            }, result.Select(r => r.ToString()));
             
             // Verify that versions with different core numbers are not included
             Assert.False(result.Any(v => v.ToString() == "1.2.2+anything"), "Should not include lower version");

--- a/source/Octopus.Versioning/Octopus/OctopusVersionMask.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionMask.cs
@@ -55,6 +55,20 @@ namespace Octopus.Versioning.Octopus
         public bool IsMask =>
             DidParse && (Major.IsSubstitute || Minor.IsSubstitute || Patch.IsSubstitute || Release.IsSubstitute || Revision.IsSubstitute || Metadata.IsSubstitute);
 
+        /// <summary>
+        /// Gets the latest masked version from a list of versions.
+        /// </summary>
+        /// <remarks>
+        /// When determining version precedence, metadata is ignored (e.g., pre-release tags 
+        /// such as "branch1.a" or build metadata). If two versions are considered equal, 
+        /// the method will return the first occurrence in the list.
+        /// </remarks>
+        /// <param name="versions">
+        /// Example: If passed a list of versions [3.2.1-branch1.a, 3.2.2-branch1.a, 3.2.2-branch1.b],
+        /// the method will determine the latest version and return 3.2.2-branch1.a. because it's the first occurrence of the two 'highest version'
+        /// </param>
+        /// <returns>The latest version based on precedence rules.</returns>
+        [Obsolete("GetLatestMaskedVersion ignores metadata when determining version precedence, it can give unexpected 'latest' version depending list of versions order.")]
         public IVersion? GetLatestMaskedVersion(List<IVersion> versions)
         {
             var maskMajor = Major.IsPresent && !Major.IsSubstitute ? int.Parse(Major.Value) : 0;

--- a/source/Octopus.Versioning/Octopus/OctopusVersionMask.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionMask.cs
@@ -68,7 +68,7 @@ namespace Octopus.Versioning.Octopus
         /// the method will determine the latest version and return 3.2.2-branch1.a. because it's the first occurrence of the two 'highest version'
         /// </param>
         /// <returns>The latest version based on precedence rules.</returns>
-        [Obsolete("GetLatestMaskedVersion ignores metadata when determining version precedence, it can give unexpected 'latest' version depending list of versions order.")]
+        [Obsolete("Its preferred to use GetLatestMaskedVersions and handle the case when there is multiple versions passed with the same version but different metadata.")]
         public IVersion? GetLatestMaskedVersion(List<IVersion> versions)
         {
             var maskMajor = Major.IsPresent && !Major.IsSubstitute ? int.Parse(Major.Value) : 0;
@@ -108,6 +108,73 @@ namespace Octopus.Versioning.Octopus
                 })
                 .OrderByDescending(o => o)
                 .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Gets all versions with the highest precedence from the provided list that match this mask.
+        /// Uses each version type's native comparison logic to determine precedence.
+        /// 
+        /// When multiple versions have identical precedence according to their native comparison,
+        /// all such versions are returned, allowing the consumer to determine the most appropriate one based
+        /// on additional context such as creation time, repository order, or other criteria.
+        /// </summary>
+        /// <param name="versions">List of versions to filter and compare</param>
+        /// <returns>All versions with the highest precedence matching the mask, or empty list if no matches found</returns>
+        public List<IVersion> GetLatestMaskedVersions(List<IVersion> versions)
+        {
+            var maskMajor = Major.IsPresent && !Major.IsSubstitute ? int.Parse(Major.Value) : 0;
+            var maskMinor = Minor.IsPresent && !Minor.IsSubstitute ? int.Parse(Minor.Value) : 0;
+            var maskBuild = Patch.IsPresent && !Patch.IsSubstitute ? int.Parse(Patch.Value) : 0;
+            var maskRevision = Revision.IsPresent && !Revision.IsSubstitute ? int.Parse(Revision.Value) : 0;
+
+            var filteredVersions = versions
+                .Where(v => v != null)
+                .Where(v =>
+                {
+                    if (Major.IsSubstitute)
+                        return true;
+
+                    if (v.Major != maskMajor)
+                        return false;
+
+                    if (Minor.IsSubstitute)
+                        return true;
+
+                    if (v.Minor != maskMinor)
+                        return false;
+
+                    if (Patch.IsSubstitute)
+                        return true;
+
+                    if (v.Patch != maskBuild)
+                        return false;
+
+                    if (Revision.IsSubstitute)
+                        return true;
+
+                    if (v.Revision != maskRevision)
+                        return false;
+
+                    return true;
+                })
+                .ToList();
+
+            if (!filteredVersions.Any())
+                return new List<IVersion>();
+
+            // Find the highest precedence version using native comparison
+            // e.g. [0.0.7+branchA.1, 0.0.7+branchA, 0.0.6+branchA] -> "0.0.7+branchA.1" 
+            // (because 0.0.7+branchA.1 was first in the list and the highest precedence version)
+            var highestVersion = filteredVersions
+                .OrderByDescending(v => v)// use IVersion.CompareTo to determine precedence (this should ignore metadata if semver)
+                .First(); 
+
+            // Because Semver does not consider metadata when determining precedence. (see: https://semver.org/#spec-item-11)
+            //  we need to return all versions that have the same highest precedence 
+            // e.g. [1.2.7+branchA.1, 1.2.7+branchA, 0.2.6+branchA] -> [1.2.7+branchA.1, 1.2.7+branchA]
+            return filteredVersions
+                .Where(v => v.CompareTo(highestVersion) == 0)
+                .ToList();
         }
 
         public IVersion GenerateVersionFromMask()

--- a/source/Octopus.Versioning/Octopus/OctopusVersionMask.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionMask.cs
@@ -71,43 +71,7 @@ namespace Octopus.Versioning.Octopus
         [Obsolete("Its preferred to use GetLatestMaskedVersions and handle the case when there is multiple versions passed with the same version but different metadata.")]
         public IVersion? GetLatestMaskedVersion(List<IVersion> versions)
         {
-            var maskMajor = Major.IsPresent && !Major.IsSubstitute ? int.Parse(Major.Value) : 0;
-            var maskMinor = Minor.IsPresent && !Minor.IsSubstitute ? int.Parse(Minor.Value) : 0;
-            var maskBuild = Patch.IsPresent && !Patch.IsSubstitute ? int.Parse(Patch.Value) : 0;
-            var maskRevision = Revision.IsPresent && !Revision.IsSubstitute ? int.Parse(Revision.Value) : 0;
-
-            return versions
-                .Where(v => v != null)
-                .Where(v =>
-                {
-                    if (Major.IsSubstitute)
-                        return true;
-
-                    if (v.Major != maskMajor)
-                        return false;
-
-                    if (Minor.IsSubstitute)
-                        return true;
-
-                    if (v.Minor != maskMinor)
-                        return false;
-
-                    if (Patch.IsSubstitute)
-                        return true;
-
-                    if (v.Patch != maskBuild)
-                        return false;
-
-                    if (Revision.IsSubstitute)
-                        return true;
-
-                    if (v.Revision != maskRevision)
-                        return false;
-
-                    return true;
-                })
-                .OrderByDescending(o => o)
-                .FirstOrDefault();
+            return GetLatestMaskedVersions(versions).FirstOrDefault();
         }
 
         /// <summary>


### PR DESCRIPTION
# Background
sc-100114 Added deterministic ordering on version metadata when version is the same.

> The Semver spec says that version metadata (everything after +) shouldn't affect precedence:
> 
> Build metadata MUST be ignored when determining version precedence. Thus two versions that differ only in the build metadata, have the same precedence. Examples: 1.0.0-alpha+001, 1.0.0+20130313144700, 1.0.0-beta+exp.sha.5114f85, 1.0.0+21AF26D3----117B344092BD.
> 
> https://semver.org/#spec-item-10

We prefer this to be deterministic as we can't be sure how the order of the versions passed to the method will be ordered by.

# Results

We have added an 'obsolete' warning to the old `GetLatestMaskedVersion`

Created a new method `GetLatestMaskedVersions` that returns all of the latest version for the consumer to handle the order if there is a matching versions with different metadata.