### PR TITLE
Updated CreateSemanticVersion to support nullable metadata and originalVersion

### DIFF
--- a/source/Octopus.Versioning/VersionFactory.cs
+++ b/source/Octopus.Versioning/VersionFactory.cs
@@ -79,8 +79,8 @@ namespace Octopus.Versioning
             int patch,
             int revision,
             IEnumerable<string> releaseLabels,
-            string metadata,
-            string originalVersion)
+            string? metadata,
+            string? originalVersion)
         {
             return new SemanticVersion(major,
                 minor,
@@ -110,8 +110,8 @@ namespace Octopus.Versioning
 
         public static IVersion CreateSemanticVersion(Version version,
             IEnumerable<string> releaseLabels,
-            string metadata,
-            string originalVersion)
+            string? metadata,
+            string? originalVersion)
         {
             return new SemanticVersion(
                 version,


### PR DESCRIPTION
In the latest NuGet version, Metadata is now nullable string, update the library to support this.

This is a No binary break: both string and string? compile to the same CLR signature but callers must recompile to pick up the new annotations and nullable flow analysis.

`CreateSemanticVersion` will now support nullable strings for `Metadata` and `OriginalVersion`

## Before:
<img width="834" height="269" alt="image" src="https://github.com/user-attachments/assets/27c54db8-3ee8-4eee-9bb8-c33da64199b3" />

## After:
<img width="729" height="271" alt="image" src="https://github.com/user-attachments/assets/3a5476de-6f9a-493f-841a-c180fcd15212" />

