### PR TITLE
Update docker tag creation to accept image digests

### DIFF
--- a/source/Octopus.Versioning.Tests/Docker/DockerVersionCompareTests.cs
+++ b/source/Octopus.Versioning.Tests/Docker/DockerVersionCompareTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using Octopus.Versioning.Docker;
 
 namespace Octopus.Versioning.Tests.Docker
 {
@@ -71,6 +72,36 @@ namespace Octopus.Versioning.Tests.Docker
             var ver2 = VersionFactory.CreateDockerTag(v2);
 
             Assert.AreNotEqual(ver1.GetHashCode(), ver2.GetHashCode());
+        }
+
+        [Test]
+        [TestCase("6.5@sha256:abc123def456", "6.5", "sha256:abc123def456")]
+        [TestCase("latest@sha256:abc123def456", "latest", "sha256:abc123def456")]
+        [TestCase("6.5", "6.5", "")]
+        public void SplitDigestShouldExtractDigestCorrectly(string input, string expectedTag, string expectedDigest)
+        {
+            var (tag, digest) = DockerTag.SplitDigest(input);
+            Assert.AreEqual(expectedTag, tag);
+            Assert.AreEqual(string.IsNullOrEmpty(expectedDigest) ? null : expectedDigest, digest);
+        }
+
+        [Test]
+        [TestCase("6.5@sha256:abc123def456", "sha256:abc123def456")]
+        [TestCase("latest", "")]
+        public void CreateDockerTagShouldPopulateDigest(string input, string expectedDigest)
+        {
+            var tag = (DockerTag)VersionFactory.CreateDockerTag(input);
+            Assert.AreEqual(string.IsNullOrEmpty(expectedDigest) ? null : expectedDigest, tag.Digest);
+        }
+
+        [Test]
+        [TestCase("6.5@sha256:abc123def456", "6.5@sha256:abc123def456")]
+        [TestCase("6.5", "6.5")]
+        [TestCase("latest", "latest")]
+        public void ToStringShouldIncludeDigestWhenPresent(string input, string expected)
+        {
+            var tag = VersionFactory.CreateDockerTag(input);
+            Assert.AreEqual(expected, tag.ToString());
         }
 
         [Test]

--- a/source/Octopus.Versioning/Docker/DockerTag.cs
+++ b/source/Octopus.Versioning/Docker/DockerTag.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using Octopus.Versioning.Octopus;
 using Octopus.Versioning.Semver;
 
@@ -8,6 +9,9 @@ namespace Octopus.Versioning.Docker
     {
         const string Latest = "latest";
         bool IsLatest => string.Compare(OriginalString, Latest, StringComparison.Ordinal) == 0;
+
+        // Matches the @sha256:<hex> suffix in a Docker tag string e.g. "6.5@sha256:abc123"
+        static readonly Regex DigestSuffixRegex = new Regex(@"@sha256:[a-f0-9]+$", RegexOptions.Compiled);
 
         public DockerTag(OctopusVersion version)
             : base(version.Prefix,
@@ -21,6 +25,21 @@ namespace Octopus.Versioning.Docker
                 version.Metadata,
                 version.OriginalString)
         {
+        }
+
+        public DockerTag(OctopusVersion version, string? digest)
+            : base(version.Prefix,
+                version.Major,
+                version.Minor,
+                version.Patch,
+                version.Revision,
+                version.Release,
+                version.ReleasePrefix,
+                version.ReleaseCounter,
+                version.Metadata,
+                version.OriginalString)
+        {
+            Digest = digest;
         }
 
         public DockerTag(string? prefix,
@@ -45,9 +64,28 @@ namespace Octopus.Versioning.Docker
         {
         }
 
+        public string? Digest { get; }
+
         public override VersionFormat Format => VersionFormat.Docker;
 
+        public override string ToString() => Digest is null ? base.ToString() : $"{base.ToString()}@{Digest}";
+
         public override bool IsPrerelease => !string.IsNullOrEmpty(Release) && OriginalString != Latest;
+
+        /// <summary>
+        /// Strips the digest suffix from a raw Docker tag string before version parsing.
+        /// e.g. "6.5@sha256:abc123" → ("6.5", "sha256:abc123"), "6.5" → ("6.5", null)
+        /// </summary>
+        public static (string Tag, string? Digest) SplitDigest(string input)
+        {
+            var match = DigestSuffixRegex.Match(input);
+            if (!match.Success)
+                return (input, null);
+
+            var tag = input.Substring(0, match.Index);
+            var digest = match.Value.Substring(1); // strip the leading '@'
+            return (tag, digest);
+        }
 
         public override int CompareTo(object obj)
         {

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -14,6 +14,7 @@ namespace Octopus.Versioning.Octopus
         const string PrereleasePrefix = "prereleaseprefix";
         const string PrereleaseCounter = "prereleasecounter";
         const string Meta = "buildmetadata";
+        const string Digest = "digest";
 
         /// <summary>
         /// Note that we don't expect to see versions with spaces around the major, minor, patch, and release.
@@ -40,7 +41,9 @@ namespace Octopus.Versioning.Octopus
             // Everything after the last digit and before the plus is the prerelease
             @$"(?:[.\-_\\])?(?<{Prerelease}>(?<{PrereleasePrefix}>[A-Za-z0-9]*?)([.\-_\\](?<{PrereleaseCounter}>[A-Za-z0-9.\-_\\]*?)?)?)?" +
             // The metadata is everything after the plus
-            $@"(?:\+(?<{Meta}>[A-Za-z0-9_\-.\\+]*?))?\s*$");
+            $@"(?:\+(?<{Meta}>[A-Za-z0-9_\-.\\+]*?))?" +
+            // Optionally match a Docker digest suffix e.g. @sha256:abc123 (used to pin an image to an exact content hash)
+            $@"(?:@(?<{Digest}>sha256:[a-f0-9]+))?\s*$");
 
         public OctopusVersion Parse(string? version)
         {

--- a/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
+++ b/source/Octopus.Versioning/Octopus/OctopusVersionParser.cs
@@ -14,7 +14,6 @@ namespace Octopus.Versioning.Octopus
         const string PrereleasePrefix = "prereleaseprefix";
         const string PrereleaseCounter = "prereleasecounter";
         const string Meta = "buildmetadata";
-        const string Digest = "digest";
 
         /// <summary>
         /// Note that we don't expect to see versions with spaces around the major, minor, patch, and release.
@@ -41,9 +40,7 @@ namespace Octopus.Versioning.Octopus
             // Everything after the last digit and before the plus is the prerelease
             @$"(?:[.\-_\\])?(?<{Prerelease}>(?<{PrereleasePrefix}>[A-Za-z0-9]*?)([.\-_\\](?<{PrereleaseCounter}>[A-Za-z0-9.\-_\\]*?)?)?)?" +
             // The metadata is everything after the plus
-            $@"(?:\+(?<{Meta}>[A-Za-z0-9_\-.\\+]*?))?" +
-            // Optionally match a Docker digest suffix e.g. @sha256:abc123 (used to pin an image to an exact content hash)
-            $@"(?:@(?<{Digest}>sha256:[a-f0-9]+))?\s*$");
+            $@"(?:\+(?<{Meta}>[A-Za-z0-9_\-.\\+]*?))?\s*$");
 
         public OctopusVersion Parse(string? version)
         {

--- a/source/Octopus.Versioning/VersionFactory.cs
+++ b/source/Octopus.Versioning/VersionFactory.cs
@@ -122,7 +122,8 @@ namespace Octopus.Versioning
 
         public static IVersion CreateDockerTag(string input)
         {
-            return new DockerTag(new OctopusVersionParser().Parse(input));
+            var (tag, digest) = DockerTag.SplitDigest(input);
+            return new DockerTag(new OctopusVersionParser().Parse(tag), digest);
         }
 
         public static IVersion? TryCreateDockerTag(string input)


### PR DESCRIPTION
# Background

<!-- Why does this PR exist? -->

Docker image references support a content digest suffix (`name:tag@sha256:<hex>`) for pinning to an exact immutable image. The DockerTag type has no support for this notation.

# Results

<!-- Describe the result of the change -->

- Added `Digest` property to `DockerTag`
- Added `SplitDigest` method that strips the `@sha256:...` suffix before parsing
- `VersionFactory.CreateDockerTag` now calls `SplitDigest` first, then constructs a `DockerTag` with the digest attached
- `ToString()` reconstructs the full reference including the digest when present
- Existing inputs without a digest are unaffected - `Digest` is null and all existing behaviour is preserved


Changes in Calamari and Octopus Server which use these new Versioning changes:
https://github.com/OctopusDeploy/Calamari/pull/2055
https://github.com/OctopusDeploy/OctopusDeploy/pull/44856

Fixes HPY-1502

## Before

<!-- Consider adding a log excerpt or screen capture. -->

Docker tag only supports `name:tag` format


## After

<!-- Consider adding a log excerpt or screen capture. -->

Docker tags now support `name:tag` or `name:tag@sha256:<digest>`

# Reducing risk
More Info: https://github.com/OctopusDeploy/OctopusDeploy/pull/44856

Test Instance: https://grace-image-digests.testoctopus.app/app#/Spaces-1/projects/test-image-digests/deployments/releases/0.0.5/deployments/Deployments-21?element=0%2FServerTasks-62_ER1BD1R8JP%2Fc4867cee3f10446992fb1528fbf17d22&activeTab=taskLog